### PR TITLE
Modify the default config to use slsa3 rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The policy configuration files are:
 
 ### Default
 
-Include a minimal set of basic checks. (Currently identical to 'minimal').
+Includes rules for levels 1, 2 & 3 of SLSA v0.1.
 
 * URL for Enterprise Contract: `github.com/enterprise-contract/config//default`
 * Source: [default/policy.yaml](https://github.com/enterprise-contract/config/blob/main/default/policy.yaml)

--- a/default/policy.yaml
+++ b/default/policy.yaml
@@ -14,7 +14,7 @@
 #     ...
 #
 description: >-
-  Include a minimal set of basic checks. (Currently identical to 'minimal').
+  Includes rules for levels 1, 2 & 3 of SLSA v0.1.
 
 publicKey: "k8s://tekton-chains/public-key"
 
@@ -28,7 +28,9 @@ sources:
 
 configuration:
   include:
-    - '@minimal'
+    - '@slsa1'
+    - '@slsa2'
+    - '@slsa3'
 
   exclude:
     # Exclude step_image_registries for now since it can cause false

--- a/src/data.json
+++ b/src/data.json
@@ -1,8 +1,8 @@
 [
   {
     "name": "default",
-    "description": "Include a minimal set of basic checks. (Currently identical to 'minimal').",
-    "include": ["@minimal"],
+    "description": "Includes rules for levels 1, 2 & 3 of SLSA v0.1.",
+    "include": ["@slsa1", "@slsa2", "@slsa3"],
     "exclude": []
   },
   {


### PR DESCRIPTION
Note that it now intentionally excludes the "minimal" collection.

The existing "slsa3" config continues to include the minimal collection, so it's still stronger than the default.