### PR TITLE
Don't show the "minimal" config in the readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,7 @@ endif
 	@mkdir -p $(*)
 	@env NAME=$(*) $(GOMPLATE) -d data=$(DATA_JSON) --file $< > $@
 
-POLICY_FILES=\
-  default/policy.yaml \
-  minimal/policy.yaml \
-  slsa1/policy.yaml \
-  slsa2/policy.yaml \
-  slsa3/policy.yaml \
-  everything/policy.yaml
+POLICY_FILES=$(shell jq -r '"\(.[].name)/policy.yaml"' src/data.json)
 
 README_TEMPLATE=src/README.md.tmpl
 README_FILE=README.md

--- a/README.md
+++ b/README.md
@@ -20,14 +20,6 @@ Includes rules for levels 1, 2 & 3 of SLSA v0.1.
     * Github URL: `https://github.com/redhat-appstudio/build-definitions.git`
     * Path in repository: [`pipelines/enterprise-contract.yaml`](https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract.yaml)
 
-### Minimal
-
-Include a minimal set of basic checks.
-
-* URL for Enterprise Contract: `github.com/enterprise-contract/config//minimal`
-* Source: [minimal/policy.yaml](https://github.com/enterprise-contract/config/blob/main/minimal/policy.yaml)
-
-
 ### Redhat
 
 Include the set of policy rules required for Red Hat products.

--- a/minimal/policy.yaml
+++ b/minimal/policy.yaml
@@ -1,4 +1,6 @@
 #
+# ** DEPRECATED **
+#
 # To use this policy with the ec command line:
 #   ec validate image \
 #     --image $IMAGE \

--- a/src/README.md.tmpl
+++ b/src/README.md.tmpl
@@ -10,6 +10,7 @@ here](https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/ho
 
 The policy configuration files are:
 {{- range ds "data" }}
+{{- if not (index . "deprecated") }}
 
 ### {{ .name | strings.Title | regexp.Replace "Slsa" "SLSA" }}
 
@@ -17,7 +18,6 @@ The policy configuration files are:
 
 * URL for Enterprise Contract: `github.com/enterprise-contract/config//{{ .name }}`
 * Source: [{{ .name }}/policy.yaml](https://github.com/enterprise-contract/config/blob/main/{{ .name }}/policy.yaml)
-{{ if ne .name "minimal" -}}
 * RHTAP Integration Test pipeline definition:
     * Github URL: `https://github.com/redhat-appstudio/build-definitions.git`
     * Path in repository: [`pipelines/enterprise-contract{{ if ne .name "default" }}-{{ .name }}{{ end }}.yaml`](https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract{{ if ne .name "default" }}-{{ .name }}{{ end }}.yaml)

--- a/src/data.json
+++ b/src/data.json
@@ -9,7 +9,8 @@
     "name": "minimal",
     "description": "Include a minimal set of basic checks.",
     "include": ["@minimal"],
-    "exclude": []
+    "exclude": [],
+    "deprecated": true
   },
   {
     "name": "redhat",

--- a/src/data.json
+++ b/src/data.json
@@ -16,7 +16,7 @@
     "name": "redhat",
     "description": "Include the set of policy rules required for Red Hat products.",
     "include": ["@redhat"],
-    "exclude": ["step_image_registries"]
+    "exclude": []
   },
   {
     "name": "slsa1",

--- a/src/policy.yaml.tmpl
+++ b/src/policy.yaml.tmpl
@@ -1,5 +1,9 @@
 {{- $name := .Env.NAME -}}{{- range ds "data" -}}{{- if eq .name $name -}}
 #
+{{ if index . "deprecated" -}}
+# ** DEPRECATED **
+#
+{{ end -}}
 # To use this policy with the ec command line:
 #   ec validate image \
 #     --image $IMAGE \


### PR DESCRIPTION
I want to remove it, but let's deprecate it first and remove it later, just in case someone out there is using it.

Plus an unrelated imrovement for the CI.