### PR TITLE
Red Hat instead of Redhat

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Includes rules for levels 1, 2 & 3 of SLSA v0.1. This is the default config used
     * Github URL: `https://github.com/redhat-appstudio/build-definitions`
     * Path in repository: [`pipelines/enterprise-contract.yaml`](https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract.yaml)
 
-### Redhat
+### Red Hat
 
 Includes the full set of rules and policies required internally by Red Hat when building Red Hat products.
 

--- a/src/README.md.tmpl
+++ b/src/README.md.tmpl
@@ -12,7 +12,7 @@ The policy configuration files are:
 {{- range ds "data" }}
 {{- if not (index . "deprecated") }}
 
-### {{ .name | strings.Title | regexp.Replace "Slsa" "SLSA" }}
+### {{ .name | strings.Title | regexp.Replace "Slsa" "SLSA" | regexp.Replace "Redhat" "Red Hat" }}
 
 {{ .description }}
 


### PR DESCRIPTION
Perhaps for the heading we go with the proper name?