### PR TITLE
Add the `name` property

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ endif
 	@mkdir -p $(*)
 	@env NAME=$(*) $(GOMPLATE) -d data=$(DATA_JSON) --file $< \
 		-t rhtap=$(POLICY_RHTAP_TEMPLATE) -t github=$(POLICY_GITHUB_TEMPLATE) \
-		> $@
+		-o $@
 
-POLICY_FILES=$(shell jq -r '"\(.[].name)/policy.yaml"' src/data.json)
+POLICY_FILES=$(shell jq -r '"\(keys | .[])/policy.yaml"' src/data.json)
 
 README_TEMPLATE=src/README.md.tmpl
 README_RHTAP_TEMPLATE=src/README-rhtap.md.tmpl

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ Includes rules for levels 1, 2 & 3 of SLSA v0.1. This is the default config used
   * Github URL: `https://github.com/redhat-appstudio/build-definitions`
   * Path in repository: [`pipelines/enterprise-contract.yaml`](https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract.yaml)
 
+### Everything (experimental)
+
+Include every rule in the default policy source. For experiments only. This is not expected to pass for RHTAP builds without excluding some rules.
+
+* URL for Enterprise Contract: `github.com/enterprise-contract/config//everything`
+* Source: [everything/policy.yaml](https://github.com/enterprise-contract/config/blob/main/everything/policy.yaml)
+* Collections:
+* RHTAP Integration Test pipeline definition:
+  * Github URL: `https://github.com/redhat-appstudio/build-definitions`
+  * Path in repository: [`pipelines/enterprise-contract-everything.yaml`](https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract-everything.yaml)
+
 ### Red Hat
 
 Includes the full set of rules and policies required internally by Red Hat when building Red Hat products.
@@ -36,7 +47,7 @@ Includes the full set of rules and policies required internally by Red Hat when 
   * Github URL: `https://github.com/redhat-appstudio/build-definitions`
   * Path in repository: [`pipelines/enterprise-contract-redhat.yaml`](https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract-redhat.yaml)
 
-### Red Hat No Hermetic
+### Red Hat (non hermetic)
 
 Includes most of the rules and policies required internally by Red Hat when building Red Hat products. It excludes the requirement of hermetic builds.
 
@@ -58,16 +69,6 @@ Rules specifically related to levels 1, 2 & 3 of SLSA v0.1, plus a set of basic 
   * Github URL: `https://github.com/redhat-appstudio/build-definitions`
   * Path in repository: [`pipelines/enterprise-contract-slsa3.yaml`](https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract-slsa3.yaml)
 
-### Everything
-
-Include every rule in the default policy source. For experiments only. This is not expected to pass for RHTAP builds without excluding some rules.
-
-* URL for Enterprise Contract: `github.com/enterprise-contract/config//everything`
-* Source: [everything/policy.yaml](https://github.com/enterprise-contract/config/blob/main/everything/policy.yaml)
-* Collections:
-* RHTAP Integration Test pipeline definition:
-  * Github URL: `https://github.com/redhat-appstudio/build-definitions`
-  * Path in repository: [`pipelines/enterprise-contract-everything.yaml`](https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract-everything.yaml)
 
 ## GitHub
 

--- a/default/policy.yaml
+++ b/default/policy.yaml
@@ -13,6 +13,7 @@
 #       value: github.com/enterprise-contract/config//default
 #     ...
 #
+name: Default
 description: >-
   Includes rules for levels 1, 2 & 3 of SLSA v0.1. This is the default config used for new RHTAP applications.
   Available collections are defined in

--- a/everything/policy.yaml
+++ b/everything/policy.yaml
@@ -13,6 +13,7 @@
 #       value: github.com/enterprise-contract/config//everything
 #     ...
 #
+name: Everything (experimental)
 description: >-
   Include every rule in the default policy source. For experiments only. This is not expected to pass for RHTAP builds without excluding some rules.
   Available collections are defined in

--- a/github-default/policy.yaml
+++ b/github-default/policy.yaml
@@ -5,6 +5,7 @@
 #     --public-key key.pub \
 #     --policy github.com/enterprise-contract/config//github-default
 #
+name: GitHub Default
 description: >-
   Rules for container images built via GitHub Workflows.
 

--- a/minimal/policy.yaml
+++ b/minimal/policy.yaml
@@ -15,6 +15,7 @@
 #       value: github.com/enterprise-contract/config//minimal
 #     ...
 #
+name: Minimal (deprecated)
 description: >-
   Includes a set of basic checks that are expected to pass for all RHTAP builds.
   Available collections are defined in

--- a/redhat-no-hermetic/policy.yaml
+++ b/redhat-no-hermetic/policy.yaml
@@ -13,6 +13,7 @@
 #       value: github.com/enterprise-contract/config//redhat-no-hermetic
 #     ...
 #
+name: Red Hat (non hermetic)
 description: >-
   Includes most of the rules and policies required internally by Red Hat when building Red Hat products. It excludes the requirement of hermetic builds.
   Available collections are defined in

--- a/redhat/policy.yaml
+++ b/redhat/policy.yaml
@@ -13,6 +13,7 @@
 #       value: github.com/enterprise-contract/config//redhat
 #     ...
 #
+name: Red Hat
 description: >-
   Includes the full set of rules and policies required internally by Red Hat when building Red Hat products.
   Available collections are defined in

--- a/slsa1/policy.yaml
+++ b/slsa1/policy.yaml
@@ -15,6 +15,7 @@
 #       value: github.com/enterprise-contract/config//slsa1
 #     ...
 #
+name: SLSA1 (deprecated)
 description: >-
   Rules specifically related to levels 1 of SLSA v0.1, plus a set of basic checks that are expected to pass for all RHTAP builds.
   Available collections are defined in

--- a/slsa2/policy.yaml
+++ b/slsa2/policy.yaml
@@ -15,6 +15,7 @@
 #       value: github.com/enterprise-contract/config//slsa2
 #     ...
 #
+name: SLSA2 (deprecated)
 description: >-
   Rules specifically related to levels 1 & 2 of SLSA v0.1, plus a set of basic checks that are expected to pass for all RHTAP builds.
   Available collections are defined in

--- a/slsa3/policy.yaml
+++ b/slsa3/policy.yaml
@@ -13,6 +13,7 @@
 #       value: github.com/enterprise-contract/config//slsa3
 #     ...
 #
+name: SLSA3
 description: >-
   Rules specifically related to levels 1, 2 & 3 of SLSA v0.1, plus a set of basic checks that are expected to pass for all RHTAP builds.
   Available collections are defined in

--- a/src/README-github.md.tmpl
+++ b/src/README-github.md.tmpl
@@ -1,12 +1,14 @@
-### {{ .name | strings.Title | regexp.Replace "Github" "GitHub" | regexp.Replace "-" " "}}
+{{ with .data }}
+### {{ .name }}
 
 {{ .description }}
 
-* URL for Enterprise Contract: `github.com/enterprise-contract/config//{{ .name }}`
-* Source: [{{ .name }}/policy.yaml](https://github.com/enterprise-contract/config/blob/main/{{ .name }}/policy.yaml)
+* URL for Enterprise Contract: `github.com/enterprise-contract/config//{{ $.directory }}`
+* Source: [{{ $.directory }}/policy.yaml](https://github.com/enterprise-contract/config/blob/main/{{ $.directory }}/policy.yaml)
 * Collections:{{ $comma := false }}{{ range .include -}}
   {{- if strings.HasPrefix "@" . -}}
     {{- if not $comma }}{{ $comma = true }} {{ else }}, {{ end -}}
     [{{ . }}](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#{{ strings.TrimPrefix "@" . }})
   {{- end -}}
+{{- end }}
 {{- end }}

--- a/src/README-rhtap.md.tmpl
+++ b/src/README-rhtap.md.tmpl
@@ -1,9 +1,10 @@
-### {{ .name | strings.Title | regexp.Replace "Slsa" "SLSA" | regexp.Replace "Redhat" "Red Hat" | regexp.Replace "Github" "GitHub" | regexp.Replace "-" " "}}
+{{ with .data }}
+### {{ .name }}
 
 {{ .description }}
 
-* URL for Enterprise Contract: `github.com/enterprise-contract/config//{{ .name }}`
-* Source: [{{ .name }}/policy.yaml](https://github.com/enterprise-contract/config/blob/main/{{ .name }}/policy.yaml)
+* URL for Enterprise Contract: `github.com/enterprise-contract/config//{{ $.directory }}`
+* Source: [{{ $.directory }}/policy.yaml](https://github.com/enterprise-contract/config/blob/main/{{ $.directory }}/policy.yaml)
 * Collections:{{ $comma := false }}{{ range .include -}}
   {{- if strings.HasPrefix "@" . -}}
     {{- if not $comma }}{{ $comma = true }} {{ else }}, {{ end -}}
@@ -12,4 +13,5 @@
 {{- end }}
 * RHTAP Integration Test pipeline definition:
   * Github URL: `https://github.com/redhat-appstudio/build-definitions`
-  * Path in repository: [`pipelines/enterprise-contract{{ if ne .name "default" }}-{{ .name }}{{ end }}.yaml`](https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract{{ if ne .name "default" }}-{{ .name }}{{ end }}.yaml)
+  * Path in repository: [`pipelines/enterprise-contract{{ if ne $.directory "default" }}-{{ $.directory }}{{ end }}.yaml`](https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract{{ if ne $.directory "default" }}-{{ $.directory }}{{ end }}.yaml)
+{{- end }}

--- a/src/README.md.tmpl
+++ b/src/README.md.tmpl
@@ -13,23 +13,28 @@ this section. They can be used when creating an Integration Test in RHTAP as per
 here](https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/proc_managing-compliance-with-the-enterprise-contract/).
 
 The policy configuration files are:
-{{ range ds "data" }}
-{{- if not (index . "deprecated") }}
-{{- if eq .environment "rhtap" }}
-{{ template "rhtap" . }}
-{{- end -}}
-{{- end -}}
+{{ range $k, $v := ds "data" }}
+  {{- with coll.Dict "directory" $k "data" $v }}
+    {{- if not (index .data "deprecated") }}
+      {{- if eq .data.environment "rhtap" }}
+        {{- template "rhtap" . }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}
+
 ## GitHub
 
 Container images built via [GitHub Actions](https://docs.github.com/actions) can be verified with
 the following policy configurations.
-{{ range ds "data" }}
-{{- if not (index . "deprecated") }}
-{{- if eq .environment "github" }}
-{{ template "github" . }}
-{{- end }}
-{{- end -}}
+{{ range $k, $v := ds "data" }}
+  {{- with coll.Dict "directory" $k "data" $v }}
+    {{- if not (index .data "deprecated") }}
+      {{- if eq .data.environment "github" }}
+        {{- template "github" . }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 ## See also
 

--- a/src/data.json
+++ b/src/data.json
@@ -1,68 +1,68 @@
-[
-  {
-    "name": "default",
+{
+  "default": {
+    "name": "Default",
     "description": "Includes rules for levels 1, 2 & 3 of SLSA v0.1. This is the default config used for new RHTAP applications.",
     "environment": "rhtap",
     "include": ["@slsa1", "@slsa2", "@slsa3"],
     "exclude": []
   },
-  {
-    "name": "minimal",
+  "minimal": {
+    "name": "Minimal (deprecated)",
     "description": "Includes a set of basic checks that are expected to pass for all RHTAP builds.",
     "environment": "rhtap",
     "include": ["@minimal"],
     "exclude": [],
     "deprecated": true
   },
-  {
-    "name": "redhat",
+  "redhat": {
+    "name": "Red Hat",
     "description": "Includes the full set of rules and policies required internally by Red Hat when building Red Hat products.",
     "environment": "rhtap",
     "include": ["@redhat"],
     "exclude": []
   },
-  {
-    "name": "redhat-no-hermetic",
+  "redhat-no-hermetic": {
+    "name": "Red Hat (non hermetic)",
     "description": "Includes most of the rules and policies required internally by Red Hat when building Red Hat products. It excludes the requirement of hermetic builds.",
     "environment": "rhtap",
     "include": ["@redhat"],
     "exclude": ["hermetic_build_task", "tasks.required_tasks_found:prefetch-dependencies"]
   },
-  {
-    "name": "slsa1",
+  "slsa1": {
+    "name": "SLSA1 (deprecated)",
     "description": "Rules specifically related to levels 1 of SLSA v0.1, plus a set of basic checks that are expected to pass for all RHTAP builds.",
     "environment": "rhtap",
     "include": ["@minimal", "@slsa1"],
     "exclude": [],
     "deprecated": true
   },
-  {
-    "name": "slsa2",
+  "slsa2": {
+    "name": "SLSA2 (deprecated)",
     "description": "Rules specifically related to levels 1 & 2 of SLSA v0.1, plus a set of basic checks that are expected to pass for all RHTAP builds.",
     "environment": "rhtap",
     "include": ["@minimal", "@slsa1", "@slsa2"],
     "exclude": [],
     "deprecated": true
   },
-  {
-    "name": "slsa3",
+  "slsa3": {
+    "name": "SLSA3",
     "description": "Rules specifically related to levels 1, 2 & 3 of SLSA v0.1, plus a set of basic checks that are expected to pass for all RHTAP builds.",
     "environment": "rhtap",
     "include": ["@minimal", "@slsa1", "@slsa2", "@slsa3"],
     "exclude": []
   },
-  {
-    "name": "everything",
+  "everything": {
+    "name": "Everything (experimental)",
     "description": "Include every rule in the default policy source. For experiments only. This is not expected to pass for RHTAP builds without excluding some rules.",
     "environment": "rhtap",
     "include": ["*"],
     "exclude": []
   },
-  {
-    "name": "github-default",
+  "github-default": {
+    "name": "GitHub Default",
     "description": "Rules for container images built via GitHub Workflows.",
     "environment": "github",
     "include": ["@github"],
     "exclude": []
   }
-]
+}

--- a/src/policy-github.yaml.tmpl
+++ b/src/policy-github.yaml.tmpl
@@ -1,3 +1,4 @@
+{{ with .data -}}
 #
 {{ if index . "deprecated" -}}
 # ** DEPRECATED **
@@ -7,8 +8,9 @@
 #   ec validate image \
 #     --image $IMAGE \
 #     --public-key key.pub \
-#     --policy github.com/enterprise-contract/config//{{ .name }}
+#     --policy github.com/enterprise-contract/config//{{ $.directory }}
 #
+name: {{.name}}
 description: >-
   {{ .description }}
 
@@ -25,3 +27,4 @@ configuration:
 
   exclude:
     {{ .exclude | toYAML | strings.Indent 4 | strings.TrimSpace }}
+{{- end -}}

--- a/src/policy-rhtap.yaml.tmpl
+++ b/src/policy-rhtap.yaml.tmpl
@@ -1,3 +1,4 @@
+{{ with .data -}}
 #
 {{ if index . "deprecated" -}}
 # ** DEPRECATED **
@@ -7,16 +8,17 @@
 #   ec validate image \
 #     --image $IMAGE \
 #     --public-key key.pub \
-#     --policy github.com/enterprise-contract/config//{{ .name }}
+#     --policy github.com/enterprise-contract/config//{{ $.directory }}
 #
 # To use with an RHTAP Enterprise Contract Integration Test CR:
 #   ...
 #   spec:
 #     params:
 #     - name: POLICY_CONFIGURATION
-#       value: github.com/enterprise-contract/config//{{ .name }}
+#       value: github.com/enterprise-contract/config//{{ $.directory }}
 #     ...
 #
+name: {{.name}}
 description: >-
   {{ .description }}
   Available collections are defined in
@@ -44,3 +46,4 @@ configuration:
     # Exclude step_image_registries for now since it can cause false
     # positives due to https://issues.redhat.com/browse/OCPBUGS-8428
     {{ .exclude | coll.Append "step_image_registries" | toYAML | strings.Indent 4 | strings.TrimSpace }}
+{{- end -}}

--- a/src/policy.yaml.tmpl
+++ b/src/policy.yaml.tmpl
@@ -1,10 +1,12 @@
 {{- $name := .Env.NAME -}}
-{{- range ds "data" -}}
-{{- if eq .name $name -}}
-{{- if eq .environment "rhtap" -}}
-{{ template "rhtap" . }}
-{{- else -}}
-{{ template "github" . }}
-{{- end -}}
-{{- end -}}
+{{- range $key, $data := ds "data" }}
+  {{- if eq $key $name }}
+    {{- with coll.Dict "directory" $key "data" $data }}
+      {{- if eq .data.environment "rhtap" }}
+        {{- template "rhtap" . }}
+      {{- else }}
+        {{- template "github" . }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
Refactors the `src/data.json` to be an object instead of an array, this way the keys are guaranteed to be unique. Separates the notion of the directory vs name, now the directory (key in the top level object) can be different than the name.

Ref. https://issues.redhat.com/browse/HACBS-2468