### PR TITLE
Remove exclusion for step_image_registries

### DIFF
--- a/default/policy.yaml
+++ b/default/policy.yaml
@@ -40,6 +40,4 @@ configuration:
     - '@slsa3'
 
   exclude:
-    # Exclude step_image_registries for now since it can cause false
-    # positives due to https://issues.redhat.com/browse/OCPBUGS-8428
-    - step_image_registries
+    []

--- a/everything/policy.yaml
+++ b/everything/policy.yaml
@@ -38,6 +38,4 @@ configuration:
     - '*'
 
   exclude:
-    # Exclude step_image_registries for now since it can cause false
-    # positives due to https://issues.redhat.com/browse/OCPBUGS-8428
-    - step_image_registries
+    []

--- a/minimal/policy.yaml
+++ b/minimal/policy.yaml
@@ -40,6 +40,4 @@ configuration:
     - '@minimal'
 
   exclude:
-    # Exclude step_image_registries for now since it can cause false
-    # positives due to https://issues.redhat.com/browse/OCPBUGS-8428
-    - step_image_registries
+    []

--- a/redhat-no-hermetic/policy.yaml
+++ b/redhat-no-hermetic/policy.yaml
@@ -38,8 +38,5 @@ configuration:
     - '@redhat'
 
   exclude:
-    # Exclude step_image_registries for now since it can cause false
-    # positives due to https://issues.redhat.com/browse/OCPBUGS-8428
     - hermetic_build_task
     - tasks.required_tasks_found:prefetch-dependencies
-    - step_image_registries

--- a/redhat/policy.yaml
+++ b/redhat/policy.yaml
@@ -38,6 +38,4 @@ configuration:
     - '@redhat'
 
   exclude:
-    # Exclude step_image_registries for now since it can cause false
-    # positives due to https://issues.redhat.com/browse/OCPBUGS-8428
-    - step_image_registries
+    []

--- a/slsa1/policy.yaml
+++ b/slsa1/policy.yaml
@@ -41,6 +41,4 @@ configuration:
     - '@slsa1'
 
   exclude:
-    # Exclude step_image_registries for now since it can cause false
-    # positives due to https://issues.redhat.com/browse/OCPBUGS-8428
-    - step_image_registries
+    []

--- a/slsa2/policy.yaml
+++ b/slsa2/policy.yaml
@@ -42,6 +42,4 @@ configuration:
     - '@slsa2'
 
   exclude:
-    # Exclude step_image_registries for now since it can cause false
-    # positives due to https://issues.redhat.com/browse/OCPBUGS-8428
-    - step_image_registries
+    []

--- a/slsa3/policy.yaml
+++ b/slsa3/policy.yaml
@@ -41,6 +41,4 @@ configuration:
     - '@slsa3'
 
   exclude:
-    # Exclude step_image_registries for now since it can cause false
-    # positives due to https://issues.redhat.com/browse/OCPBUGS-8428
-    - step_image_registries
+    []

--- a/src/policy-rhtap.yaml.tmpl
+++ b/src/policy-rhtap.yaml.tmpl
@@ -43,7 +43,5 @@ configuration:
     {{ .include | toYAML | strings.Indent 4 | strings.TrimSpace }}
 
   exclude:
-    # Exclude step_image_registries for now since it can cause false
-    # positives due to https://issues.redhat.com/browse/OCPBUGS-8428
-    {{ .exclude | coll.Append "step_image_registries" | toYAML | strings.Indent 4 | strings.TrimSpace }}
+    {{ .exclude | toYAML | strings.Indent 4 | strings.TrimSpace }}
 {{- end -}}


### PR DESCRIPTION
The policy package `step_image_registries` is no longer included in any collection. As such, there is no need to exclude it in these policy configs.

Ref: HACBS-1972