### PR TITLE
Configure dependabot to run weekly (TZ)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,4 @@ updates:
     schedule:
       interval: weekly
       time: '15:00'
+      timezone: Etc/UTC


### PR DESCRIPTION
Makes the timezone explicit.

ref: issues.redhat.com/browse/EC-198
