### PR TITLE
Do not set publicKey on RHTAP configs

### DIFF
--- a/default/policy.yaml
+++ b/default/policy.yaml
@@ -22,8 +22,6 @@ description: >-
   See the docs on how to include and exclude rules
   https://redhat-appstudio.github.io/docs.stonesoup.io/ec-policies/policy_configuration.html#_including_and_excluding_rules.
 
-publicKey: "k8s://openshift-pipelines/public-key"
-
 sources:
   - name: Default
     policy:

--- a/everything/policy.yaml
+++ b/everything/policy.yaml
@@ -22,8 +22,6 @@ description: >-
   See the docs on how to include and exclude rules
   https://redhat-appstudio.github.io/docs.stonesoup.io/ec-policies/policy_configuration.html#_including_and_excluding_rules.
 
-publicKey: "k8s://openshift-pipelines/public-key"
-
 sources:
   - name: Default
     policy:

--- a/hack/update-infra-deployments.sh
+++ b/hack/update-infra-deployments.sh
@@ -80,6 +80,7 @@ for policy_config in $policy_configs; do
         },
         "spec": . }
         | .spec.sources[].policy = [strenv(policy)]
+        | .spec.publicKey = "k8s://openshift-pipelines/public-key"
         | sort_keys(..) ' \
         "${policy_config}"  >> "${OUTPUT}"
 done

--- a/minimal/policy.yaml
+++ b/minimal/policy.yaml
@@ -24,8 +24,6 @@ description: >-
   See the docs on how to include and exclude rules
   https://redhat-appstudio.github.io/docs.stonesoup.io/ec-policies/policy_configuration.html#_including_and_excluding_rules.
 
-publicKey: "k8s://openshift-pipelines/public-key"
-
 sources:
   - name: Default
     policy:

--- a/redhat-no-hermetic/policy.yaml
+++ b/redhat-no-hermetic/policy.yaml
@@ -22,8 +22,6 @@ description: >-
   See the docs on how to include and exclude rules
   https://redhat-appstudio.github.io/docs.stonesoup.io/ec-policies/policy_configuration.html#_including_and_excluding_rules.
 
-publicKey: "k8s://openshift-pipelines/public-key"
-
 sources:
   - name: Default
     policy:

--- a/redhat/policy.yaml
+++ b/redhat/policy.yaml
@@ -22,8 +22,6 @@ description: >-
   See the docs on how to include and exclude rules
   https://redhat-appstudio.github.io/docs.stonesoup.io/ec-policies/policy_configuration.html#_including_and_excluding_rules.
 
-publicKey: "k8s://openshift-pipelines/public-key"
-
 sources:
   - name: Default
     policy:

--- a/slsa3/policy.yaml
+++ b/slsa3/policy.yaml
@@ -22,8 +22,6 @@ description: >-
   See the docs on how to include and exclude rules
   https://redhat-appstudio.github.io/docs.stonesoup.io/ec-policies/policy_configuration.html#_including_and_excluding_rules.
 
-publicKey: "k8s://openshift-pipelines/public-key"
-
 sources:
   - name: Default
     policy:

--- a/src/policy-rhtap.yaml.tmpl
+++ b/src/policy-rhtap.yaml.tmpl
@@ -27,8 +27,6 @@ description: >-
   See the docs on how to include and exclude rules
   https://redhat-appstudio.github.io/docs.stonesoup.io/ec-policies/policy_configuration.html#_including_and_excluding_rules.
 
-publicKey: "k8s://openshift-pipelines/public-key"
-
 sources:
   - name: Default
     policy:


### PR DESCRIPTION
The RHTAP configs have been updated to no longer specify the `publicKey` attributes. This makes them more flexible by allowing them to be used in different contexts.

The `update-infra-deployments.sh` script is updated to dynamically inject the `publicKey` attribute when updating the ECP resources in the infra-deployments repository. Since those resources are expected to be used only in RHTAP, the publicKey value is still useful there.

Ref: EC-146