### PR TITLE
Create EC policy config for validating Task definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,28 +6,30 @@ DATA_JSON=src/data.json
 
 POLICY_TEMPLATE=src/policy.yaml.tmpl
 POLICY_RHTAP_TEMPLATE=src/policy-rhtap.yaml.tmpl
+POLICY_RHTAP_TASKS_TEMPLATE=src/policy-rhtap-tasks.yaml.tmpl
 POLICY_GITHUB_TEMPLATE=src/policy-github.yaml.tmpl
 
 ifndef GOMPLATE
 	GOMPLATE=gomplate
 endif
 
-%/policy.yaml: $(POLICY_TEMPLATE) $(DATA_JSON) $(POLICY_RHTAP_TEMPLATE) $(POLICY_GITHUB_TEMPLATE) Makefile
+%/policy.yaml: $(POLICY_TEMPLATE) $(DATA_JSON) $(POLICY_RHTAP_TEMPLATE) $(POLICY_RHTAP_TASKS_TEMPLATE) $(POLICY_GITHUB_TEMPLATE) Makefile
 	@mkdir -p $(*)
 	@env NAME=$(*) $(GOMPLATE) -d data=$(DATA_JSON) --file $< \
-		-t rhtap=$(POLICY_RHTAP_TEMPLATE) -t github=$(POLICY_GITHUB_TEMPLATE) \
+		-t rhtap=$(POLICY_RHTAP_TEMPLATE) -t rhtap-tasks=$(POLICY_RHTAP_TASKS_TEMPLATE) -t github=$(POLICY_GITHUB_TEMPLATE) \
 		-o $@
 
 POLICY_FILES=$(shell jq -r '"\(keys | .[])/policy.yaml"' src/data.json)
 
 README_TEMPLATE=src/README.md.tmpl
 README_RHTAP_TEMPLATE=src/README-rhtap.md.tmpl
+README_RHTAP_TASKS_TEMPLATE=src/README-rhtap-tasks.md.tmpl
 README_GITHUB_TEMPLATE=src/README-github.md.tmpl
 README_FILE=README.md
 
-$(README_FILE): $(README_TEMPLATE) $(DATA_JSON) $(README_RHTAP_TEMPLATE) $(README_GITHUB_TEMPLATE) Makefile
+$(README_FILE): $(README_TEMPLATE) $(DATA_JSON) $(README_RHTAP_TEMPLATE) $(README_RHTAP_TASKS_TEMPLATE) $(README_GITHUB_TEMPLATE) Makefile
 	@$(GOMPLATE) -d data=$(DATA_JSON) --file $< \
-		-t rhtap=$(README_RHTAP_TEMPLATE) -t github=$(README_GITHUB_TEMPLATE) \
+		-t rhtap=$(README_RHTAP_TEMPLATE) -t rhtap-tasks=$(README_RHTAP_TASKS_TEMPLATE) -t github=$(README_GITHUB_TEMPLATE) \
 		> $@
 
 all: $(POLICY_FILES) $(README_FILE)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,21 @@ Rules specifically related to levels 1, 2 & 3 of SLSA v0.1, plus a set of basic 
   * Path in repository: [`pipelines/enterprise-contract-slsa3.yaml`](https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract-slsa3.yaml)
 
 
+## Red Hat Trusted Application Pipeline - Tasks
+
+These are policy rules used to verify Tekton Task definitions meet the Red Hat guidelines for being
+considered trusted.
+
+The policy configuration files are:
+
+### Red Hat Trusted Tasks
+
+Rules used to verify Tekton Task definitions comply to Red Hat's standards.
+
+* URL for Enterprise Contract: `github.com/enterprise-contract/config//redhat-trusted-tasks`
+* Source: [redhat-trusted-tasks/policy.yaml](https://github.com/enterprise-contract/config/blob/main/redhat-trusted-tasks/policy.yaml)
+
+
 ## GitHub
 
 Container images built via [GitHub Actions](https://docs.github.com/actions) can be verified with

--- a/hack/verify-policy-sources.sh
+++ b/hack/verify-policy-sources.sh
@@ -55,7 +55,7 @@ verify_url() {
     fi
 }
 
-policy_configs="$(< src/data.json yq '.[].name + "/policy.yaml"' -r)"
+policy_configs="$(< src/data.json yq '. | keys | .[] + "/policy.yaml"' -r)"
 
 policy_urls="$(yq eval '.sources[].policy[]' $policy_configs | grep -v -- '---' | sort -u)"
 for url in $policy_urls; do

--- a/redhat-trusted-tasks/policy.yaml
+++ b/redhat-trusted-tasks/policy.yaml
@@ -1,0 +1,21 @@
+# To use this policy with the ec command line:
+#   ec validate input \
+#     --file $FILE \
+#     --policy github.com/enterprise-contract/config//redhat-trusted-tasks
+#
+name: Red Hat Trusted Tasks
+description: >-
+  Rules used to verify Tekton Task definitions comply to Red Hat's standards.
+sources:
+  - name: Default
+    policy:
+      - github.com/enterprise-contract/ec-policies//policy/lib
+      - github.com/enterprise-contract/ec-policies//policy/task
+    data:
+      - github.com/release-engineering/rhtap-ec-policy//data
+    config:
+      include:
+        - kind
+        - step_image_registries
+      exclude:
+        []

--- a/src/README-rhtap-tasks.md.tmpl
+++ b/src/README-rhtap-tasks.md.tmpl
@@ -1,0 +1,8 @@
+{{ with .data }}
+### {{ .name }}
+
+{{ .description }}
+
+* URL for Enterprise Contract: `github.com/enterprise-contract/config//{{ $.directory }}`
+* Source: [{{ $.directory }}/policy.yaml](https://github.com/enterprise-contract/config/blob/main/{{ $.directory }}/policy.yaml)
+{{- end }}

--- a/src/README.md.tmpl
+++ b/src/README.md.tmpl
@@ -23,6 +23,22 @@ The policy configuration files are:
   {{- end }}
 {{- end }}
 
+## Red Hat Trusted Application Pipeline - Tasks
+
+These are policy rules used to verify Tekton Task definitions meet the Red Hat guidelines for being
+considered trusted.
+
+The policy configuration files are:
+{{ range $k, $v := ds "data" }}
+  {{- with coll.Dict "directory" $k "data" $v }}
+    {{- if not (index .data "deprecated") }}
+      {{- if eq .data.environment "rhtap-tasks" }}
+        {{- template "rhtap-tasks" . }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
 ## GitHub
 
 Container images built via [GitHub Actions](https://docs.github.com/actions) can be verified with

--- a/src/data.json
+++ b/src/data.json
@@ -26,7 +26,10 @@
     "description": "Includes most of the rules and policies required internally by Red Hat when building Red Hat products. It excludes the requirement of hermetic builds.",
     "environment": "rhtap",
     "include": ["@redhat"],
-    "exclude": ["hermetic_build_task", "tasks.required_tasks_found:prefetch-dependencies"]
+    "exclude": [
+      "hermetic_build_task",
+      "tasks.required_tasks_found:prefetch-dependencies"
+    ]
   },
   "slsa3": {
     "name": "SLSA3",
@@ -40,6 +43,13 @@
     "description": "Include every rule in the default policy source. For experiments only. This is not expected to pass for RHTAP builds without excluding some rules.",
     "environment": "rhtap",
     "include": ["*"],
+    "exclude": []
+  },
+  "redhat-trusted-tasks": {
+    "name": "Red Hat Trusted Tasks",
+    "description": "Rules used to verify Tekton Task definitions comply to Red Hat's standards.",
+    "environment": "rhtap-tasks",
+    "include": ["kind", "step_image_registries"],
     "exclude": []
   },
   "github-default": {

--- a/src/policy-rhtap-tasks.yaml.tmpl
+++ b/src/policy-rhtap-tasks.yaml.tmpl
@@ -1,0 +1,23 @@
+{{ with .data -}}
+# To use this policy with the ec command line:
+#   ec validate input \
+#     --file $FILE \
+#     --policy github.com/enterprise-contract/config//{{ $.directory }}
+#
+name: {{.name}}
+description: >-
+  {{ .description }}
+sources:
+  - name: Default
+    policy:
+      - github.com/enterprise-contract/ec-policies//policy/lib
+      - github.com/enterprise-contract/ec-policies//policy/task
+    data:
+      - github.com/release-engineering/rhtap-ec-policy//data
+    config:
+      include:
+        {{ .include | toYAML | strings.Indent 8 | strings.TrimSpace }}
+      exclude:
+        {{ .exclude | toYAML | strings.Indent 8 | strings.TrimSpace }}
+
+{{- end -}}

--- a/src/policy.yaml.tmpl
+++ b/src/policy.yaml.tmpl
@@ -4,6 +4,8 @@
     {{- with coll.Dict "directory" $key "data" $data }}
       {{- if eq .data.environment "rhtap" }}
         {{- template "rhtap" . }}
+      {{- else if eq .data.environment "rhtap-tasks" }}
+        {{- template "rhtap-tasks" . }}
       {{- else }}
         {{- template "github" . }}
       {{- end }}


### PR DESCRIPTION
Ref: EC-358

This adds a policy config that can be used to verify Task definitions. Since this requires policies from a different namespace (task instead of release), this is handled as a new "environment".

The `update-infra-deployments.sh` script is adjusted to handle propagating updates from the new config to the infra-deployments repo. It should be a no-op at first because the infra-deployments repo doesn't contain any instances of the ec-task-policy bundle image. It's important to do this now so things don't break when we do add it there.

A separate commit is added to fix the verify-policy-sources script which was broken.