### PR TITLE
Disable step_image_registries for tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,4 @@ ci: update-needed-check yaml-parse-check
 
 # See https://docs.gomplate.ca/installing/ for other installation methods
 install-gomplate:
-	go install github.com/hairyhenderson/gomplate/v4/cmd/gomplate@latest
+	go install github.com/hairyhenderson/gomplate/v3/cmd/gomplate@latest

--- a/redhat-trusted-tasks/policy.yaml
+++ b/redhat-trusted-tasks/policy.yaml
@@ -16,6 +16,5 @@ sources:
     config:
       include:
         - kind
-        - step_image_registries
       exclude:
         []

--- a/src/data.json
+++ b/src/data.json
@@ -49,7 +49,7 @@
     "name": "Red Hat Trusted Tasks",
     "description": "Rules used to verify Tekton Task definitions comply to Red Hat's standards.",
     "environment": "rhtap-tasks",
-    "include": ["kind", "step_image_registries"],
+    "include": ["kind"],
     "exclude": []
   },
   "github-default": {


### PR DESCRIPTION
This commit removes the `step_image_registries` policies from the `redhat-trusted-tasks` policy config. Currently, the Task definitions we want to validate don't conform to those policies. This will be re-enabled in EC-374.