### PR TITLE
Introduce a config for RHTAP's TSSC samples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,20 @@ DATA_JSON=src/data.json
 POLICY_TEMPLATE=src/policy.yaml.tmpl
 POLICY_KONFLUX_TEMPLATE=src/policy-konflux.yaml.tmpl
 POLICY_KONFLUX_TASKS_TEMPLATE=src/policy-konflux-tasks.yaml.tmpl
+POLICY_RHTAP_TEMPLATE=src/policy-rhtap.yaml.tmpl
 POLICY_GITHUB_TEMPLATE=src/policy-github.yaml.tmpl
 
 ifndef GOMPLATE
 	GOMPLATE=gomplate
 endif
 
-%/policy.yaml: $(POLICY_TEMPLATE) $(DATA_JSON) $(POLICY_KONFLUX_TEMPLATE) $(POLICY_KONFLUX_TASKS_TEMPLATE) $(POLICY_GITHUB_TEMPLATE) Makefile
+%/policy.yaml: $(POLICY_TEMPLATE) $(DATA_JSON) $(POLICY_KONFLUX_TEMPLATE) $(POLICY_KONFLUX_TASKS_TEMPLATE) $(POLICY_RHTAP_TEMPLATE) $(POLICY_GITHUB_TEMPLATE) Makefile
 	@mkdir -p $(*)
 	@env NAME=$(*) $(GOMPLATE) -d data=$(DATA_JSON) --file $< \
-		-t konflux=$(POLICY_KONFLUX_TEMPLATE) -t konflux-tasks=$(POLICY_KONFLUX_TASKS_TEMPLATE) -t github=$(POLICY_GITHUB_TEMPLATE) \
+		-t konflux=$(POLICY_KONFLUX_TEMPLATE) \
+		-t konflux-tasks=$(POLICY_KONFLUX_TASKS_TEMPLATE) \
+		-t rhtap=$(POLICY_RHTAP_TEMPLATE) \
+		-t github=$(POLICY_GITHUB_TEMPLATE) \
 		-o $@
 
 POLICY_FILES=$(shell jq -r '"\(keys | .[])/policy.yaml"' src/data.json)
@@ -24,12 +28,16 @@ POLICY_FILES=$(shell jq -r '"\(keys | .[])/policy.yaml"' src/data.json)
 README_TEMPLATE=src/README.md.tmpl
 README_KONFLUX_TEMPLATE=src/README-konflux.md.tmpl
 README_KONFLUX_TASKS_TEMPLATE=src/README-konflux-tasks.md.tmpl
+README_RHTAP_TEMPLATE=src/README-rhtap.md.tmpl
 README_GITHUB_TEMPLATE=src/README-github.md.tmpl
 README_FILE=README.md
 
-$(README_FILE): $(README_TEMPLATE) $(DATA_JSON) $(README_KONFLUX_TEMPLATE) $(README_KONFLUX_TASKS_TEMPLATE) $(README_GITHUB_TEMPLATE) Makefile
+$(README_FILE): $(README_TEMPLATE) $(DATA_JSON) $(README_KONFLUX_TEMPLATE) $(README_KONFLUX_TASKS_TEMPLATE) $(README_RHTAP_TEMPLATE) $(README_GITHUB_TEMPLATE) Makefile
 	@$(GOMPLATE) -d data=$(DATA_JSON) --file $< \
-		-t konflux=$(README_KONFLUX_TEMPLATE) -t konflux-tasks=$(README_KONFLUX_TASKS_TEMPLATE) -t github=$(README_GITHUB_TEMPLATE) \
+		-t konflux=$(README_KONFLUX_TEMPLATE) \
+		-t konflux-tasks=$(README_KONFLUX_TASKS_TEMPLATE) \
+		-t rhtap=$(README_RHTAP_TEMPLATE) \
+		-t github=$(README_GITHUB_TEMPLATE) \
 		> $@
 
 all: $(POLICY_FILES) $(README_FILE)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,28 @@ Rules specifically related to levels 1, 2 & 3 of SLSA v0.1, plus a set of basic 
   * Path in repository: [`pipelines/enterprise-contract-slsa3.yaml`](https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract-slsa3.yaml)
 
 
+## Red Hat Trusted Application Pipeline (RHTAP)
+
+This configuration is designed to be used with RHTAP. The sample RHTAP
+pipelines include [a GitOps PR pipeline with an EC
+check](https://github.com/redhat-appstudio/tssc-sample-pipelines/blob/main/pac/pipelines/gitops-pull-request-rhtap.yaml).
+The pipeline uses the [`verify-enterprise-contract` task](https://github.com/redhat-appstudio/tssc-sample-pipelines/blob/main/pac/tasks/verify-enterprise-contract.yaml),
+with this EC configuration.
+
+It's similar to the Konflux CI default configuration but for compatibility and
+stability reasons it doesn't use policies directly from `main` branch.
+
+The policy configuration files are:
+
+### TSSC Default Stable
+
+Includes rules for levels 1, 2 & 3 of SLSA v0.1. This is the default config used by the RHTAP's TSSC templates.
+
+* URL for Enterprise Contract: `github.com/enterprise-contract/config//tssc-default`
+* Source: [tssc-default/policy.yaml](https://github.com/enterprise-contract/config/blob/main/tssc-default/policy.yaml)
+* Collections: [@slsa3](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#slsa3)
+
+
 ## Konflux CI & Red Hat Trusted Application Pipeline (RHTAP) - Tasks
 
 These are policy rules used to verify Tekton Task definitions meet the Red Hat guidelines for being

--- a/src/README-rhtap.md.tmpl
+++ b/src/README-rhtap.md.tmpl
@@ -1,0 +1,14 @@
+{{ with .data }}
+### {{ .name }}
+
+{{ .description }}
+
+* URL for Enterprise Contract: `github.com/enterprise-contract/config//{{ $.directory }}`
+* Source: [{{ $.directory }}/policy.yaml](https://github.com/enterprise-contract/config/blob/main/{{ $.directory }}/policy.yaml)
+* Collections:{{ $comma := false }}{{ range .include -}}
+  {{- if strings.HasPrefix "@" . -}}
+    {{- if not $comma }}{{ $comma = true }} {{ else }}, {{ end -}}
+    [{{ . }}](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#{{ strings.TrimPrefix "@" . }})
+  {{- end -}}
+{{- end }}
+{{- end }}

--- a/src/README.md.tmpl
+++ b/src/README.md.tmpl
@@ -23,6 +23,28 @@ The policy configuration files are:
   {{- end }}
 {{- end }}
 
+## Red Hat Trusted Application Pipeline (RHTAP)
+
+This configuration is designed to be used with RHTAP. The sample RHTAP
+pipelines include [a GitOps PR pipeline with an EC
+check](https://github.com/redhat-appstudio/tssc-sample-pipelines/blob/main/pac/pipelines/gitops-pull-request-rhtap.yaml).
+The pipeline uses the [`verify-enterprise-contract` task](https://github.com/redhat-appstudio/tssc-sample-pipelines/blob/main/pac/tasks/verify-enterprise-contract.yaml),
+with this EC configuration.
+
+It's similar to the Konflux CI default configuration but for compatibility and
+stability reasons it doesn't use policies directly from `main` branch.
+
+The policy configuration files are:
+{{ range $k, $v := ds "data" }}
+  {{- with coll.Dict "directory" $k "data" $v }}
+    {{- if not (index .data "deprecated") }}
+      {{- if eq .data.environment "rhtap" }}
+        {{- template "rhtap" . }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
 ## Konflux CI & Red Hat Trusted Application Pipeline (RHTAP) - Tasks
 
 These are policy rules used to verify Tekton Task definitions meet the Red Hat guidelines for being

--- a/src/data.json
+++ b/src/data.json
@@ -6,6 +6,14 @@
     "include": ["@slsa3"],
     "exclude": []
   },
+  "tssc-default": {
+    "name": "TSSC Default Stable",
+    "description": "Includes rules for levels 1, 2 & 3 of SLSA v0.1. This is the default config used by the RHTAP's TSSC templates.",
+    "environment": "rhtap",
+    "ecPoliciesRef": "tssc-stable",
+    "include": ["@slsa3"],
+    "exclude": []
+  },
   "minimal": {
     "name": "Minimal (deprecated)",
     "description": "Includes a set of basic checks that are expected to pass for all Konflux builds.",

--- a/src/policy-rhtap.yaml.tmpl
+++ b/src/policy-rhtap.yaml.tmpl
@@ -1,0 +1,28 @@
+{{ with .data -}}
+#
+{{ if index . "deprecated" -}}
+# ** DEPRECATED **
+#
+{{ end -}}
+# To use this policy with the ec command line:
+#   ec validate image \
+#     --image $IMAGE \
+#     --public-key key.pub \
+#     --policy github.com/enterprise-contract/config//{{ $.directory }}
+#
+name: {{.name}}
+description: >-
+  {{ .description }}
+
+sources:
+  - name: Default
+    policy:
+      - github.com/enterprise-contract/ec-policies//policy/lib{{ with .ecPoliciesRef }}?ref={{ . }}{{ end }}
+      - github.com/enterprise-contract/ec-policies//policy/release{{ with .ecPoliciesRef }}?ref={{ . }}{{ end }}
+    data: []
+    config:
+      include:
+        {{ .include | toYAML | strings.Indent 8 | strings.TrimSpace }}
+      exclude:
+        {{ .exclude | toYAML | strings.Indent 8 | strings.TrimSpace }}
+{{- end -}}

--- a/src/policy.yaml.tmpl
+++ b/src/policy.yaml.tmpl
@@ -4,6 +4,8 @@
     {{- with coll.Dict "directory" $key "data" $data }}
       {{- if eq .data.environment "konflux" }}
         {{- template "konflux" . }}
+      {{- else if eq .data.environment "rhtap" }}
+        {{- template "rhtap" . }}
       {{- else if eq .data.environment "konflux-tasks" }}
         {{- template "konflux-tasks" . }}
       {{- else }}

--- a/tssc-default/policy.yaml
+++ b/tssc-default/policy.yaml
@@ -1,0 +1,22 @@
+#
+# To use this policy with the ec command line:
+#   ec validate image \
+#     --image $IMAGE \
+#     --public-key key.pub \
+#     --policy github.com/enterprise-contract/config//tssc-default
+#
+name: TSSC Default Stable
+description: >-
+  Includes rules for levels 1, 2 & 3 of SLSA v0.1. This is the default config used by the RHTAP's TSSC templates.
+
+sources:
+  - name: Default
+    policy:
+      - github.com/enterprise-contract/ec-policies//policy/lib?ref=tssc-stable
+      - github.com/enterprise-contract/ec-policies//policy/release?ref=tssc-stable
+    data: []
+    config:
+      include:
+        - '@slsa3'
+      exclude:
+        []


### PR DESCRIPTION
The motivation is to make it so the RHTAP sample templates do not always pull in the latest rego policies from main branch of ec-policies.

Because RHTAP users might not always be using the latest version of the ec cli, there's a chance that an update to the policies might not be backwards compatible, which could break RHTAP useres. So that's why it's better if RHTAP users are not using main branch ec-policies.

In future we might want to provide more than one of these, e.g. a stable config for RHTAP 1.0 and for RHTAP 1.2. For that, let's follow the example set by the `tssc-sample-templates` repo. If they create different branches for different RHTAP releases, then we can follow suit. For now let's start with just one config file.

Ref: https://issues.redhat.com/browse/EC-605