### PR TITLE
Stop mentioning the obsolete pipeline definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@ Includes rules for levels 1, 2 & 3 of SLSA v0.1. This is the default config used
 * URL for Enterprise Contract: `github.com/enterprise-contract/config//default`
 * Source: [default/policy.yaml](https://github.com/enterprise-contract/config/blob/main/default/policy.yaml)
 * Collections: [@slsa3](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#slsa3)
-* Konflux Integration Test pipeline definition:
-  * Github URL: `https://github.com/redhat-appstudio/build-definitions`
-  * Path in repository: [`pipelines/enterprise-contract.yaml`](https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract.yaml)
 
 ### Everything (experimental)
 
@@ -32,9 +29,6 @@ Include every rule in the default policy source. For experiments only. This is n
 * URL for Enterprise Contract: `github.com/enterprise-contract/config//everything`
 * Source: [everything/policy.yaml](https://github.com/enterprise-contract/config/blob/main/everything/policy.yaml)
 * Collections:
-* Konflux Integration Test pipeline definition:
-  * Github URL: `https://github.com/redhat-appstudio/build-definitions`
-  * Path in repository: [`pipelines/enterprise-contract-everything.yaml`](https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract-everything.yaml)
 
 ### Red Hat
 
@@ -43,9 +37,6 @@ Includes the full set of rules and policies required internally by Red Hat when 
 * URL for Enterprise Contract: `github.com/enterprise-contract/config//redhat`
 * Source: [redhat/policy.yaml](https://github.com/enterprise-contract/config/blob/main/redhat/policy.yaml)
 * Collections: [@redhat](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#redhat)
-* Konflux Integration Test pipeline definition:
-  * Github URL: `https://github.com/redhat-appstudio/build-definitions`
-  * Path in repository: [`pipelines/enterprise-contract-redhat.yaml`](https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract-redhat.yaml)
 
 ### Red Hat (non hermetic)
 
@@ -54,9 +45,6 @@ Includes most of the rules and policies required internally by Red Hat when buil
 * URL for Enterprise Contract: `github.com/enterprise-contract/config//redhat-no-hermetic`
 * Source: [redhat-no-hermetic/policy.yaml](https://github.com/enterprise-contract/config/blob/main/redhat-no-hermetic/policy.yaml)
 * Collections: [@redhat](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#redhat)
-* Konflux Integration Test pipeline definition:
-  * Github URL: `https://github.com/redhat-appstudio/build-definitions`
-  * Path in repository: [`pipelines/enterprise-contract-redhat-no-hermetic.yaml`](https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract-redhat-no-hermetic.yaml)
 
 ### SLSA3
 
@@ -65,9 +53,6 @@ Rules specifically related to levels 1, 2 & 3 of SLSA v0.1, plus a set of basic 
 * URL for Enterprise Contract: `github.com/enterprise-contract/config//slsa3`
 * Source: [slsa3/policy.yaml](https://github.com/enterprise-contract/config/blob/main/slsa3/policy.yaml)
 * Collections: [@minimal](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#minimal), [@slsa3](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#slsa3)
-* Konflux Integration Test pipeline definition:
-  * Github URL: `https://github.com/redhat-appstudio/build-definitions`
-  * Path in repository: [`pipelines/enterprise-contract-slsa3.yaml`](https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract-slsa3.yaml)
 
 
 ## Konflux CI & Red Hat Trusted Application Pipeline (RHTAP) - Tasks

--- a/default/policy.yaml
+++ b/default/policy.yaml
@@ -13,6 +13,10 @@
 #       value: github.com/enterprise-contract/config//default
 #     ...
 #
+# In Konflux there is also an EnterpriseContractPolicy CRD containing this policy.
+# You can use it by specifying `enterprise-contract-service/default` as
+# the param value instead of the GitHub URL.
+#
 name: Default
 description: >-
   Includes rules for levels 1, 2 & 3 of SLSA v0.1. This is the default config used for new Konflux applications.

--- a/everything/policy.yaml
+++ b/everything/policy.yaml
@@ -13,6 +13,10 @@
 #       value: github.com/enterprise-contract/config//everything
 #     ...
 #
+# In Konflux there is also an EnterpriseContractPolicy CRD containing this policy.
+# You can use it by specifying `enterprise-contract-service/everything` as
+# the param value instead of the GitHub URL.
+#
 name: Everything (experimental)
 description: >-
   Include every rule in the default policy source. For experiments only. This is not expected to pass for Konflux builds without excluding some rules.

--- a/minimal/policy.yaml
+++ b/minimal/policy.yaml
@@ -15,6 +15,10 @@
 #       value: github.com/enterprise-contract/config//minimal
 #     ...
 #
+# In Konflux there is also an EnterpriseContractPolicy CRD containing this policy.
+# You can use it by specifying `enterprise-contract-service/minimal` as
+# the param value instead of the GitHub URL.
+#
 name: Minimal (deprecated)
 description: >-
   Includes a set of basic checks that are expected to pass for all Konflux builds.

--- a/redhat-no-hermetic/policy.yaml
+++ b/redhat-no-hermetic/policy.yaml
@@ -13,6 +13,10 @@
 #       value: github.com/enterprise-contract/config//redhat-no-hermetic
 #     ...
 #
+# In Konflux there is also an EnterpriseContractPolicy CRD containing this policy.
+# You can use it by specifying `enterprise-contract-service/redhat-no-hermetic` as
+# the param value instead of the GitHub URL.
+#
 name: Red Hat (non hermetic)
 description: >-
   Includes most of the rules and policies required internally by Red Hat when building Red Hat products. It excludes the requirement of hermetic builds.

--- a/redhat/policy.yaml
+++ b/redhat/policy.yaml
@@ -13,6 +13,10 @@
 #       value: github.com/enterprise-contract/config//redhat
 #     ...
 #
+# In Konflux there is also an EnterpriseContractPolicy CRD containing this policy.
+# You can use it by specifying `enterprise-contract-service/redhat` as
+# the param value instead of the GitHub URL.
+#
 name: Red Hat
 description: >-
   Includes the full set of rules and policies required internally by Red Hat when building Red Hat products.

--- a/slsa3/policy.yaml
+++ b/slsa3/policy.yaml
@@ -13,6 +13,10 @@
 #       value: github.com/enterprise-contract/config//slsa3
 #     ...
 #
+# In Konflux there is also an EnterpriseContractPolicy CRD containing this policy.
+# You can use it by specifying `enterprise-contract-service/slsa3` as
+# the param value instead of the GitHub URL.
+#
 name: SLSA3
 description: >-
   Rules specifically related to levels 1, 2 & 3 of SLSA v0.1, plus a set of basic checks that are expected to pass for all Konflux builds.

--- a/src/README-konflux.md.tmpl
+++ b/src/README-konflux.md.tmpl
@@ -11,7 +11,4 @@
     [{{ . }}](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#{{ strings.TrimPrefix "@" . }})
   {{- end -}}
 {{- end }}
-* Konflux Integration Test pipeline definition:
-  * Github URL: `https://github.com/redhat-appstudio/build-definitions`
-  * Path in repository: [`pipelines/enterprise-contract{{ if ne $.directory "default" }}-{{ $.directory }}{{ end }}.yaml`](https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract{{ if ne $.directory "default" }}-{{ $.directory }}{{ end }}.yaml)
 {{- end }}

--- a/src/policy-konflux.yaml.tmpl
+++ b/src/policy-konflux.yaml.tmpl
@@ -18,6 +18,10 @@
 #       value: github.com/enterprise-contract/config//{{ $.directory }}
 #     ...
 #
+# In Konflux there is also an EnterpriseContractPolicy CRD containing this policy.
+# You can use it by specifying `enterprise-contract-service/{{ $.directory }}` as
+# the param value instead of the GitHub URL.
+#
 name: {{.name}}
 description: >-
   {{ .description }}


### PR DESCRIPTION
Also mention the related Konflux CRDs for each config.