### PR TITLE
Introduce stable versioned configs for RHTAP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,20 @@ DATA_JSON=src/data.json
 POLICY_TEMPLATE=src/policy.yaml.tmpl
 POLICY_KONFLUX_TEMPLATE=src/policy-konflux.yaml.tmpl
 POLICY_KONFLUX_TASKS_TEMPLATE=src/policy-konflux-tasks.yaml.tmpl
+POLICY_VERSIONED_TEMPLATE=src/policy-versioned.yaml.tmpl
 POLICY_GITHUB_TEMPLATE=src/policy-github.yaml.tmpl
 
 ifndef GOMPLATE
 	GOMPLATE=gomplate
 endif
 
-%/policy.yaml: $(POLICY_TEMPLATE) $(DATA_JSON) $(POLICY_KONFLUX_TEMPLATE) $(POLICY_KONFLUX_TASKS_TEMPLATE) $(POLICY_GITHUB_TEMPLATE) Makefile
+%/policy.yaml: $(POLICY_TEMPLATE) $(DATA_JSON) $(POLICY_KONFLUX_TEMPLATE) $(POLICY_KONFLUX_TASKS_TEMPLATE) $(POLICY_VERSIONED_TEMPLATE) $(POLICY_GITHUB_TEMPLATE) Makefile
 	@mkdir -p $(*)
 	@env NAME=$(*) $(GOMPLATE) -d data=$(DATA_JSON) --file $< \
-		-t konflux=$(POLICY_KONFLUX_TEMPLATE) -t konflux-tasks=$(POLICY_KONFLUX_TASKS_TEMPLATE) -t github=$(POLICY_GITHUB_TEMPLATE) \
+		-t konflux=$(POLICY_KONFLUX_TEMPLATE) \
+		-t konflux-tasks=$(POLICY_KONFLUX_TASKS_TEMPLATE) \
+		-t versioned=$(POLICY_VERSIONED_TEMPLATE) \
+		-t github=$(POLICY_GITHUB_TEMPLATE) \
 		-o $@
 
 POLICY_FILES=$(shell jq -r '"\(keys | .[])/policy.yaml"' src/data.json)
@@ -24,12 +28,16 @@ POLICY_FILES=$(shell jq -r '"\(keys | .[])/policy.yaml"' src/data.json)
 README_TEMPLATE=src/README.md.tmpl
 README_KONFLUX_TEMPLATE=src/README-konflux.md.tmpl
 README_KONFLUX_TASKS_TEMPLATE=src/README-konflux-tasks.md.tmpl
+README_VERSIONED_TEMPLATE=src/README-versioned.md.tmpl
 README_GITHUB_TEMPLATE=src/README-github.md.tmpl
 README_FILE=README.md
 
-$(README_FILE): $(README_TEMPLATE) $(DATA_JSON) $(README_KONFLUX_TEMPLATE) $(README_KONFLUX_TASKS_TEMPLATE) $(README_GITHUB_TEMPLATE) Makefile
+$(README_FILE): $(README_TEMPLATE) $(DATA_JSON) $(README_KONFLUX_TEMPLATE) $(README_KONFLUX_TASKS_TEMPLATE) $(README_VERSIONED_TEMPLATE) $(README_GITHUB_TEMPLATE) Makefile
 	@$(GOMPLATE) -d data=$(DATA_JSON) --file $< \
-		-t konflux=$(README_KONFLUX_TEMPLATE) -t konflux-tasks=$(README_KONFLUX_TASKS_TEMPLATE) -t github=$(README_GITHUB_TEMPLATE) \
+		-t konflux=$(README_KONFLUX_TEMPLATE) \
+		-t konflux-tasks=$(README_KONFLUX_TASKS_TEMPLATE) \
+		-t versioned=$(README_VERSIONED_TEMPLATE) \
+		-t github=$(README_GITHUB_TEMPLATE) \
 		> $@
 
 all: $(POLICY_FILES) $(README_FILE)

--- a/README.md
+++ b/README.md
@@ -22,14 +22,6 @@ Includes rules for levels 1, 2 & 3 of SLSA v0.1. This is the default config used
 * Source: [default/policy.yaml](https://github.com/enterprise-contract/config/blob/main/default/policy.yaml)
 * Collections: [@slsa3](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#slsa3)
 
-### Everything (experimental)
-
-Include every rule in the default policy source. For experiments only. This is not expected to pass for Konflux builds without excluding some rules.
-
-* URL for Enterprise Contract: `github.com/enterprise-contract/config//everything`
-* Source: [everything/policy.yaml](https://github.com/enterprise-contract/config/blob/main/everything/policy.yaml)
-* Collections:
-
 ### Red Hat
 
 Includes the full set of rules and policies required internally by Red Hat when building Red Hat products.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,46 @@ Rules specifically related to levels 1, 2 & 3 of SLSA v0.1, plus a set of basic 
 * Collections: [@minimal](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#minimal), [@slsa3](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#slsa3)
 
 
+## Stable (versioned policies)
+
+The main branch of the [enterprise-contract/ec-policies](https://github.com/enterprise-contract/ec-policies)
+is always tested with the [latest build of ec-cli](https://github.com/enterprise-contract/ec-cli/releases). If
+your environment uses a specific version of ec-cli, such as
+[the official Red Hat build](https://catalog.redhat.com/software/containers/rhtas/ec-rhel9/65f1f9dcfc649a18c6075de5),
+then you can use one of these instead of the
+[main branch default](https://github.com/enterprise-contract/config?tab=readme-ov-file#default).
+
+They are similar to the [Konflux CI "default"](#default) configuration except they use a specific branch
+of the policies repo for stability and compatiblity with specific verisons of ec. These configurations are
+suggested for use in [Red Hat Trusted Application Pipeline](https://developers.redhat.com/products/trusted-application-pipeline/overview) templates.
+
+The policy configuration files are:
+
+### Default (v0.1-alpha)
+
+Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.1-alpha.
+
+* URL for Enterprise Contract: `github.com/enterprise-contract/config//default-v0.1-alpha`
+* Source: [default-v0.1-alpha/policy.yaml](https://github.com/enterprise-contract/config/blob/main/default-v0.1-alpha/policy.yaml)
+* Collections: [@slsa3](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#slsa3)
+
+### Default (v0.2)
+
+Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.2.
+
+* URL for Enterprise Contract: `github.com/enterprise-contract/config//default-v0.2`
+* Source: [default-v0.2/policy.yaml](https://github.com/enterprise-contract/config/blob/main/default-v0.2/policy.yaml)
+* Collections: [@slsa3](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#slsa3)
+
+### Default (v0.4)
+
+Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.4
+
+* URL for Enterprise Contract: `github.com/enterprise-contract/config//default-v0.4`
+* Source: [default-v0.4/policy.yaml](https://github.com/enterprise-contract/config/blob/main/default-v0.4/policy.yaml)
+* Collections: [@slsa3](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#slsa3)
+
+
 ## Konflux CI & Red Hat Trusted Application Pipeline (RHTAP) - Tasks
 
 These are policy rules used to verify Tekton Task definitions meet the Red Hat guidelines for being

--- a/default-v0.1-alpha/policy.yaml
+++ b/default-v0.1-alpha/policy.yaml
@@ -1,0 +1,22 @@
+#
+# To use this policy with the ec command line:
+#   ec validate image \
+#     --image $IMAGE \
+#     --public-key key.pub \
+#     --policy github.com/enterprise-contract/config//default-v0.1-alpha
+#
+name: Default (v0.1-alpha)
+description: >-
+  Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.1-alpha.
+
+sources:
+  - name: Default
+    policy:
+      - github.com/enterprise-contract/ec-policies//policy/lib?ref=release-v0.1-alpha
+      - github.com/enterprise-contract/ec-policies//policy/release?ref=release-v0.1-alpha
+    data: []
+    config:
+      include:
+        - '@slsa3'
+      exclude:
+        []

--- a/default-v0.1-alpha/policy.yaml
+++ b/default-v0.1-alpha/policy.yaml
@@ -18,5 +18,4 @@ sources:
     config:
       include:
         - '@slsa3'
-      exclude:
-        []
+      exclude: []

--- a/default-v0.2/policy.yaml
+++ b/default-v0.2/policy.yaml
@@ -18,5 +18,4 @@ sources:
     config:
       include:
         - '@slsa3'
-      exclude:
-        []
+      exclude: []

--- a/default-v0.2/policy.yaml
+++ b/default-v0.2/policy.yaml
@@ -1,0 +1,22 @@
+#
+# To use this policy with the ec command line:
+#   ec validate image \
+#     --image $IMAGE \
+#     --public-key key.pub \
+#     --policy github.com/enterprise-contract/config//default-v0.2
+#
+name: Default (v0.2)
+description: >-
+  Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.2.
+
+sources:
+  - name: Default
+    policy:
+      - github.com/enterprise-contract/ec-policies//policy/lib?ref=release-v0.2
+      - github.com/enterprise-contract/ec-policies//policy/release?ref=release-v0.2
+    data: []
+    config:
+      include:
+        - '@slsa3'
+      exclude:
+        []

--- a/default-v0.4/policy.yaml
+++ b/default-v0.4/policy.yaml
@@ -1,0 +1,22 @@
+#
+# To use this policy with the ec command line:
+#   ec validate image \
+#     --image $IMAGE \
+#     --public-key key.pub \
+#     --policy github.com/enterprise-contract/config//default-v0.4
+#
+name: Default (v0.4)
+description: >-
+  Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.4
+
+sources:
+  - name: Default
+    policy:
+      - github.com/enterprise-contract/ec-policies//policy/lib?ref=release-v0.4
+      - github.com/enterprise-contract/ec-policies//policy/release?ref=release-v0.4
+    data: []
+    config:
+      include:
+        - '@slsa3'
+      exclude:
+        []

--- a/default-v0.4/policy.yaml
+++ b/default-v0.4/policy.yaml
@@ -18,5 +18,4 @@ sources:
     config:
       include:
         - '@slsa3'
-      exclude:
-        []
+      exclude: []

--- a/default/policy.yaml
+++ b/default/policy.yaml
@@ -37,5 +37,4 @@ sources:
     config:
       include:
         - '@slsa3'
-      exclude:
-        []
+      exclude: []

--- a/everything/policy.yaml
+++ b/everything/policy.yaml
@@ -1,4 +1,6 @@
 #
+# ** DEPRECATED **
+#
 # To use this policy with the ec command line:
 #   ec validate image \
 #     --image $IMAGE \

--- a/everything/policy.yaml
+++ b/everything/policy.yaml
@@ -37,5 +37,4 @@ sources:
     config:
       include:
         - '*'
-      exclude:
-        []
+      exclude: []

--- a/github-default/policy.yaml
+++ b/github-default/policy.yaml
@@ -18,5 +18,4 @@ sources:
     config:
       include:
         - '@github'
-      exclude:
-        []
+      exclude: []

--- a/minimal/policy.yaml
+++ b/minimal/policy.yaml
@@ -39,5 +39,4 @@ sources:
     config:
       include:
         - '@minimal'
-      exclude:
-        []
+      exclude: []

--- a/redhat-trusted-tasks/policy.yaml
+++ b/redhat-trusted-tasks/policy.yaml
@@ -16,5 +16,4 @@ sources:
     config:
       include:
         - kind
-      exclude:
-        []
+      exclude: []

--- a/redhat/policy.yaml
+++ b/redhat/policy.yaml
@@ -37,5 +37,4 @@ sources:
     config:
       include:
         - '@redhat'
-      exclude:
-        []
+      exclude: []

--- a/slsa3/policy.yaml
+++ b/slsa3/policy.yaml
@@ -38,5 +38,4 @@ sources:
       include:
         - '@minimal'
         - '@slsa3'
-      exclude:
-        []
+      exclude: []

--- a/src/README-versioned.md.tmpl
+++ b/src/README-versioned.md.tmpl
@@ -1,0 +1,14 @@
+{{ with .data }}
+### {{ .name }}
+
+{{ .description }}
+
+* URL for Enterprise Contract: `github.com/enterprise-contract/config//{{ $.directory }}`
+* Source: [{{ $.directory }}/policy.yaml](https://github.com/enterprise-contract/config/blob/main/{{ $.directory }}/policy.yaml)
+* Collections:{{ $comma := false }}{{ range .include -}}
+  {{- if strings.HasPrefix "@" . -}}
+    {{- if not $comma }}{{ $comma = true }} {{ else }}, {{ end -}}
+    [{{ . }}](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#{{ strings.TrimPrefix "@" . }})
+  {{- end -}}
+{{- end }}
+{{- end }}

--- a/src/README.md.tmpl
+++ b/src/README.md.tmpl
@@ -23,6 +23,30 @@ The policy configuration files are:
   {{- end }}
 {{- end }}
 
+## Stable (versioned policies)
+
+The main branch of the [enterprise-contract/ec-policies](https://github.com/enterprise-contract/ec-policies)
+is always tested with the [latest build of ec-cli](https://github.com/enterprise-contract/ec-cli/releases). If
+your environment uses a specific version of ec-cli, such as
+[the official Red Hat build](https://catalog.redhat.com/software/containers/rhtas/ec-rhel9/65f1f9dcfc649a18c6075de5),
+then you can use one of these instead of the
+[main branch default](https://github.com/enterprise-contract/config?tab=readme-ov-file#default).
+
+They are similar to the [Konflux CI "default"](#default) configuration except they use a specific branch
+of the policies repo for stability and compatiblity with specific verisons of ec. These configurations are
+suggested for use in [Red Hat Trusted Application Pipeline](https://developers.redhat.com/products/trusted-application-pipeline/overview) templates.
+
+The policy configuration files are:
+{{ range $k, $v := ds "data" }}
+  {{- with coll.Dict "directory" $k "data" $v }}
+    {{- if not (index .data "deprecated") }}
+      {{- if eq .data.environment "versioned" }}
+        {{- template "versioned" . }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
 ## Konflux CI & Red Hat Trusted Application Pipeline (RHTAP) - Tasks
 
 These are policy rules used to verify Tekton Task definitions meet the Red Hat guidelines for being

--- a/src/data.json
+++ b/src/data.json
@@ -86,7 +86,8 @@
     "include": [
       "*"
     ],
-    "exclude": []
+    "exclude": [],
+    "deprecated": true
   },
   "redhat-trusted-tasks": {
     "name": "Red Hat Trusted Tasks",

--- a/src/data.json
+++ b/src/data.json
@@ -3,14 +3,48 @@
     "name": "Default",
     "description": "Includes rules for levels 1, 2 & 3 of SLSA v0.1. This is the default config used for new Konflux applications.",
     "environment": "konflux",
-    "include": ["@slsa3"],
+    "include": [
+      "@slsa3"
+    ],
+    "exclude": []
+  },
+  "default-v0.1-alpha": {
+    "name": "Default (v0.1-alpha)",
+    "description": "Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.1-alpha.",
+    "environment": "versioned",
+    "ecPoliciesRef": "release-v0.1-alpha",
+    "include": [
+      "@slsa3"
+    ],
+    "exclude": []
+  },
+  "default-v0.2": {
+    "name": "Default (v0.2)",
+    "description": "Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.2.",
+    "environment": "versioned",
+    "ecPoliciesRef": "release-v0.2",
+    "include": [
+      "@slsa3"
+    ],
+    "exclude": []
+  },
+  "default-v0.4": {
+    "name": "Default (v0.4)",
+    "description": "Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.4",
+    "environment": "versioned",
+    "ecPoliciesRef": "release-v0.4",
+    "include": [
+      "@slsa3"
+    ],
     "exclude": []
   },
   "minimal": {
     "name": "Minimal (deprecated)",
     "description": "Includes a set of basic checks that are expected to pass for all Konflux builds.",
     "environment": "konflux",
-    "include": ["@minimal"],
+    "include": [
+      "@minimal"
+    ],
     "exclude": [],
     "deprecated": true
   },
@@ -18,14 +52,18 @@
     "name": "Red Hat",
     "description": "Includes the full set of rules and policies required internally by Red Hat when building Red Hat products.",
     "environment": "konflux",
-    "include": ["@redhat"],
+    "include": [
+      "@redhat"
+    ],
     "exclude": []
   },
   "redhat-no-hermetic": {
     "name": "Red Hat (non hermetic)",
     "description": "Includes most of the rules and policies required internally by Red Hat when building Red Hat products. It excludes the requirement of hermetic builds.",
     "environment": "konflux",
-    "include": ["@redhat"],
+    "include": [
+      "@redhat"
+    ],
     "exclude": [
       "hermetic_build_task",
       "tasks.required_tasks_found:prefetch-dependencies"
@@ -35,28 +73,37 @@
     "name": "SLSA3",
     "description": "Rules specifically related to levels 1, 2 & 3 of SLSA v0.1, plus a set of basic checks that are expected to pass for all Konflux builds.",
     "environment": "konflux",
-    "include": ["@minimal", "@slsa3"],
+    "include": [
+      "@minimal",
+      "@slsa3"
+    ],
     "exclude": []
   },
   "everything": {
     "name": "Everything (experimental)",
     "description": "Include every rule in the default policy source. For experiments only. This is not expected to pass for Konflux builds without excluding some rules.",
     "environment": "konflux",
-    "include": ["*"],
+    "include": [
+      "*"
+    ],
     "exclude": []
   },
   "redhat-trusted-tasks": {
     "name": "Red Hat Trusted Tasks",
     "description": "Rules used to verify Tekton Task definitions comply to Red Hat's standards.",
     "environment": "konflux-tasks",
-    "include": ["kind"],
+    "include": [
+      "kind"
+    ],
     "exclude": []
   },
   "github-default": {
     "name": "GitHub Default",
     "description": "Rules for container images built via GitHub Workflows.",
     "environment": "github",
-    "include": ["@github"],
+    "include": [
+      "@github"
+    ],
     "exclude": []
   }
 }

--- a/src/policy-github.yaml.tmpl
+++ b/src/policy-github.yaml.tmpl
@@ -23,6 +23,6 @@ sources:
     config:
       include:
         {{ .include | toYAML | strings.Indent 8 | strings.TrimSpace }}
-      exclude:
-        {{ .exclude | toYAML | strings.Indent 8 | strings.TrimSpace }}
+      {{ if eq (len .exclude) 0 }}exclude: []{{ else }}exclude:
+        {{ .exclude | toYAML | strings.Indent 8 | strings.TrimSpace }}{{ end }}
 {{- end -}}

--- a/src/policy-konflux-tasks.yaml.tmpl
+++ b/src/policy-konflux-tasks.yaml.tmpl
@@ -17,7 +17,7 @@ sources:
     config:
       include:
         {{ .include | toYAML | strings.Indent 8 | strings.TrimSpace }}
-      exclude:
-        {{ .exclude | toYAML | strings.Indent 8 | strings.TrimSpace }}
+      {{ if eq (len .exclude) 0 }}exclude: []{{ else }}exclude:
+        {{ .exclude | toYAML | strings.Indent 8 | strings.TrimSpace }}{{ end }}
 
 {{- end -}}

--- a/src/policy-konflux.yaml.tmpl
+++ b/src/policy-konflux.yaml.tmpl
@@ -42,7 +42,7 @@ sources:
     config:
       include:
         {{ .include | toYAML | strings.Indent 8 | strings.TrimSpace }}
-      exclude:
-        {{ .exclude | toYAML | strings.Indent 8 | strings.TrimSpace }}
+      {{ if eq (len .exclude) 0 }}exclude: []{{ else }}exclude:
+        {{ .exclude | toYAML | strings.Indent 8 | strings.TrimSpace }}{{ end }}
 
 {{- end -}}

--- a/src/policy-versioned.yaml.tmpl
+++ b/src/policy-versioned.yaml.tmpl
@@ -1,0 +1,28 @@
+{{ with .data -}}
+#
+{{ if index . "deprecated" -}}
+# ** DEPRECATED **
+#
+{{ end -}}
+# To use this policy with the ec command line:
+#   ec validate image \
+#     --image $IMAGE \
+#     --public-key key.pub \
+#     --policy github.com/enterprise-contract/config//{{ $.directory }}
+#
+name: {{.name}}
+description: >-
+  {{ .description }}
+
+sources:
+  - name: Default
+    policy:
+      - github.com/enterprise-contract/ec-policies//policy/lib{{ with .ecPoliciesRef }}?ref={{ . }}{{ end }}
+      - github.com/enterprise-contract/ec-policies//policy/release{{ with .ecPoliciesRef }}?ref={{ . }}{{ end }}
+    data: []
+    config:
+      include:
+        {{ .include | toYAML | strings.Indent 8 | strings.TrimSpace }}
+      exclude:
+        {{ .exclude | toYAML | strings.Indent 8 | strings.TrimSpace }}
+{{- end -}}

--- a/src/policy-versioned.yaml.tmpl
+++ b/src/policy-versioned.yaml.tmpl
@@ -23,6 +23,7 @@ sources:
     config:
       include:
         {{ .include | toYAML | strings.Indent 8 | strings.TrimSpace }}
-      exclude:
-        {{ .exclude | toYAML | strings.Indent 8 | strings.TrimSpace }}
+      {{ if eq (len .exclude) 0 }}exclude: []{{ else }}exclude:
+        {{ .exclude | toYAML | strings.Indent 8 | strings.TrimSpace }}{{ end }}
+
 {{- end -}}

--- a/src/policy.yaml.tmpl
+++ b/src/policy.yaml.tmpl
@@ -4,6 +4,8 @@
     {{- with coll.Dict "directory" $key "data" $data }}
       {{- if eq .data.environment "konflux" }}
         {{- template "konflux" . }}
+      {{- else if eq .data.environment "versioned" }}
+        {{- template "versioned" . }}
       {{- else if eq .data.environment "konflux-tasks" }}
         {{- template "konflux-tasks" . }}
       {{- else }}


### PR DESCRIPTION
The motivation is to make it so the RHTAP sample templates do not always pull in the latest rego policies from main branch of ec-policies.

Because RHTAP users might not always be using the latest version of the ec cli, there's a chance that an update to the policies might not be backwards compatible, which could break RHTAP useres. So that's why it's better if RHTAP users are not using main branch ec-policies.

The versions are based on the downstream RH builds of EC, which are what gets shipped with RHTAS and hence with RHTAP.

Ref: https://issues.redhat.com/browse/EC-605
See also: https://issues.redhat.com/browse/EC-695