### PR TITLE
Add config for use with RHTAP Jenkins pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,18 @@ Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.2.
 
 ### Default (v0.4)
 
-Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.4
+Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.4.
 
 * URL for Enterprise Contract: `github.com/enterprise-contract/config//default-v0.4`
 * Source: [default-v0.4/policy.yaml](https://github.com/enterprise-contract/config/blob/main/default-v0.4/policy.yaml)
+* Collections: [@slsa3](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#slsa3)
+
+### RHTAP Jenkins (v0.4)
+
+Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.4 and images built with the RHTAP Jenkins pipeline.
+
+* URL for Enterprise Contract: `github.com/enterprise-contract/config//rhtap-jenkins-v0.4`
+* Source: [rhtap-jenkins-v0.4/policy.yaml](https://github.com/enterprise-contract/config/blob/main/rhtap-jenkins-v0.4/policy.yaml)
 * Collections: [@slsa3](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#slsa3)
 
 

--- a/rhtap-jenkins-v0.4/policy.yaml
+++ b/rhtap-jenkins-v0.4/policy.yaml
@@ -3,11 +3,11 @@
 #   ec validate image \
 #     --image $IMAGE \
 #     --public-key key.pub \
-#     --policy github.com/enterprise-contract/config//default-v0.4
+#     --policy github.com/enterprise-contract/config//rhtap-jenkins-v0.4
 #
-name: Default (v0.4)
+name: RHTAP Jenkins (v0.4)
 description: >-
-  Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.4.
+  Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.4 and images built with the RHTAP Jenkins pipeline.
 
 sources:
   - name: Default
@@ -18,4 +18,5 @@ sources:
     config:
       include:
         - '@slsa3'
-      exclude: []
+      exclude:
+        - slsa_source_correlated

--- a/src/data.json
+++ b/src/data.json
@@ -30,13 +30,25 @@
   },
   "default-v0.4": {
     "name": "Default (v0.4)",
-    "description": "Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.4",
+    "description": "Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.4.",
     "environment": "versioned",
     "ecPoliciesRef": "release-v0.4",
     "include": [
       "@slsa3"
     ],
     "exclude": []
+  },
+  "rhtap-jenkins-v0.4": {
+    "name": "RHTAP Jenkins (v0.4)",
+    "description": "Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.4 and images built with the RHTAP Jenkins pipeline.",
+    "environment": "versioned",
+    "ecPoliciesRef": "release-v0.4",
+    "include": [
+      "@slsa3"
+    ],
+    "exclude": [
+      "slsa_source_correlated"
+    ]
   },
   "minimal": {
     "name": "Minimal (deprecated)",


### PR DESCRIPTION
We're currently working on Jenkins pipeline support for RHTAP 1.2.

At this stage the EC check in the Jenkins pipeline templates doesn't provide the git references, so the slsa_source_correlated checks are always going to fail. For now we'll skip them.

Notes:
- There may be more changes here later, e.g. we could decide to use a @slsa3-jenkins collection, or even a different set of policies tailored towards the attestations being produced in the Jenkins build.
- I was surprised that all the other @slsa3 collection checks passed with the minimal attestation being created currently in the Jenkins pipeline, but let's take a closer look at that later.


Ref: [EC-746](https://issues.redhat.com/browse/EC-746)