### PR TITLE
Pin the policies refs used in rhtap-jenkins config

### DIFF
--- a/rhtap-jenkins/policy.yaml
+++ b/rhtap-jenkins/policy.yaml
@@ -12,8 +12,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib?ref=main
-      - github.com/enterprise-contract/ec-policies//policy/release?ref=main
+      - github.com/enterprise-contract/ec-policies//policy/lib?ref=release-v0.5
+      - github.com/enterprise-contract/ec-policies//policy/release?ref=release-v0.5
     data: []
     config:
       include:

--- a/src/data.yaml
+++ b/src/data.yaml
@@ -9,16 +9,15 @@ default:
     - '@slsa3'
   exclude: []
 
-# For now we're rapidly adding things to @rhtap-jenkins so it's better to use
-# main branch. Once we're closer to shipping RHTAP 1.2 we might want to use a
-# git branch ref such as release-v0.5 for stability.
+# In future we might want to maintain multiple versioned configs for
+# rhtap-jenkins also, but for now there is just one of them
 rhtap-jenkins:
   name: RHTAP Jenkins
   description: >-
     Includes rules suitable for use with the attestations created by RHTAP
     Jenkins build pipelines.
   environment: versioned
-  ecPoliciesRef: main
+  ecPoliciesRef: release-v0.5
   include:
     - '@rhtap-jenkins'
   exclude: []


### PR DESCRIPTION
There was a new rego function added recently to ec called `ec.oci.image_files`. The main branch of ec-policies now uses that function and hence causes problems for older versions of ec where that function is not defined.

To avoid breaking RHTAP Jenkins users, pin the policy refs so that the the `ec.oci.image_file` function is not encountered.

Note:
- We can't use the release-v0.4 branch here, even though it's likely RHTAP users will initially have ec-v0.4 because the Jenkins rego rules were added after that branch was created.
- However, ec-v0.5 should be compatible with the release-v0.5 ec-policies rego. Actually it's expected that RHTAP users will upgrade to RHTAS 1.1.0 when it is released, which does include ec-v0.5.
- So that's why it should be fine to use the release-v0.5 branch, even though it's a little newer version that the ec-v0.4 binary likely being used.