### PR TITLE
Pin policies used by RHTAP Multi-CI

### DIFF
--- a/rhtap-github/policy.yaml
+++ b/rhtap-github/policy.yaml
@@ -12,8 +12,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib?ref=main
-      - github.com/enterprise-contract/ec-policies//policy/release?ref=main
+      - github.com/enterprise-contract/ec-policies//policy/lib?ref=release-v0.5-rhtap
+      - github.com/enterprise-contract/ec-policies//policy/release?ref=release-v0.5-rhtap
     data: []
     config:
       include:

--- a/rhtap-gitlab/policy.yaml
+++ b/rhtap-gitlab/policy.yaml
@@ -12,8 +12,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib?ref=main
-      - github.com/enterprise-contract/ec-policies//policy/release?ref=main
+      - github.com/enterprise-contract/ec-policies//policy/lib?ref=release-v0.5-rhtap
+      - github.com/enterprise-contract/ec-policies//policy/release?ref=release-v0.5-rhtap
     data: []
     config:
       include:

--- a/src/data.yaml
+++ b/src/data.yaml
@@ -28,8 +28,7 @@ rhtap-gitlab:
     Includes rules suitable for use with the attestations created by RHTAP
     GitLab build pipelines.
   environment: versioned
-  # Pin to a release branch in future
-  ecPoliciesRef: main
+  ecPoliciesRef: release-v0.5-rhtap
   include:
     - '@rhtap-gitlab'
   exclude: []
@@ -40,8 +39,7 @@ rhtap-github:
     Includes rules suitable for use with the attestations created by RHTAP
     GitHub build pipelines.
   environment: versioned
-  # Pin to a release branch in future
-  ecPoliciesRef: main
+  ecPoliciesRef: release-v0.5-rhtap
   include:
     - '@rhtap-github'
   exclude: []


### PR DESCRIPTION
With the imminent GA of RHTAP 1.3, let's pin this reference for stability. I pushed the branch to ec-policies just now on sha 158a9858c7be2250cd1ec8e7b80c7dca0d8ca01d .

It means that changes from EC-1032 didn't get merged in time, but that's okay, we'll include them in future RHTAP releases.

I considered introducing an RHTAP version number in the branch name, e.g. `release-v0.5-rhtap-1.3` but decided against it, though we may want to do somethinhg like that in future.

Ref: https://issues.redhat.com/browse/EC-1029