### PR TITLE
Add new v0.6 stable config for RHTAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,29 +85,13 @@ Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.4
 * Source: [default-v0.4/policy.yaml](https://github.com/enterprise-contract/config/blob/main/default-v0.4/policy.yaml)
 * Collections: [@slsa3](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#slsa3)
 
-### RHTAP GitHub
+### RHTAP
 
-Includes rules suitable for use with the attestations created by RHTAP GitHub build pipelines.
+Includes rules suitable for use with the attestations created by RHTAP.
 
-* URL for Enterprise Contract: `github.com/enterprise-contract/config//rhtap-github`
-* Source: [rhtap-github/policy.yaml](https://github.com/enterprise-contract/config/blob/main/rhtap-github/policy.yaml)
-* Collections: [@rhtap-github](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#rhtap-github)
-
-### RHTAP GitLab
-
-Includes rules suitable for use with the attestations created by RHTAP GitLab build pipelines.
-
-* URL for Enterprise Contract: `github.com/enterprise-contract/config//rhtap-gitlab`
-* Source: [rhtap-gitlab/policy.yaml](https://github.com/enterprise-contract/config/blob/main/rhtap-gitlab/policy.yaml)
-* Collections: [@rhtap-gitlab](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#rhtap-gitlab)
-
-### RHTAP Jenkins
-
-Includes rules suitable for use with the attestations created by RHTAP Jenkins build pipelines.
-
-* URL for Enterprise Contract: `github.com/enterprise-contract/config//rhtap-jenkins`
-* Source: [rhtap-jenkins/policy.yaml](https://github.com/enterprise-contract/config/blob/main/rhtap-jenkins/policy.yaml)
-* Collections: [@rhtap-jenkins](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#rhtap-jenkins)
+* URL for Enterprise Contract: `github.com/enterprise-contract/config//rhtap-v0.6`
+* Source: [rhtap-v0.6/policy.yaml](https://github.com/enterprise-contract/config/blob/main/rhtap-v0.6/policy.yaml)
+* Collections: [@rhtap-multi-ci](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#rhtap-multi-ci)
 
 
 ## Konflux CI & Red Hat Trusted Application Pipeline (RHTAP) - Tasks

--- a/rhtap-github/policy.yaml
+++ b/rhtap-github/policy.yaml
@@ -1,4 +1,6 @@
 #
+# ** DEPRECATED **
+#
 # To use this policy with the ec command line:
 #   ec validate image \
 #     --image $IMAGE \

--- a/rhtap-gitlab/policy.yaml
+++ b/rhtap-gitlab/policy.yaml
@@ -1,4 +1,6 @@
 #
+# ** DEPRECATED **
+#
 # To use this policy with the ec command line:
 #   ec validate image \
 #     --image $IMAGE \

--- a/rhtap-jenkins/policy.yaml
+++ b/rhtap-jenkins/policy.yaml
@@ -1,4 +1,6 @@
 #
+# ** DEPRECATED **
+#
 # To use this policy with the ec command line:
 #   ec validate image \
 #     --image $IMAGE \

--- a/rhtap-v0.6/policy.yaml
+++ b/rhtap-v0.6/policy.yaml
@@ -1,0 +1,21 @@
+#
+# To use this policy with the ec command line:
+#   ec validate image \
+#     --image $IMAGE \
+#     --public-key key.pub \
+#     --policy github.com/enterprise-contract/config//rhtap-v0.6
+#
+name: RHTAP
+description: >-
+  Includes rules suitable for use with the attestations created by RHTAP.
+
+sources:
+  - name: Default
+    policy:
+      - github.com/enterprise-contract/ec-policies//policy/lib?ref=release-v0.6
+      - github.com/enterprise-contract/ec-policies//policy/release?ref=release-v0.6
+    data: []
+    config:
+      include:
+        - '@rhtap-multi-ci'
+      exclude: []

--- a/src/data.yaml
+++ b/src/data.yaml
@@ -9,8 +9,19 @@ default:
     - '@slsa3'
   exclude: []
 
-# In future we might want to maintain multiple versioned configs
-# for rhtap, but for now there is just one of them per ci-type
+# Compatible with all the different RHTAP CI environments.
+# For use with Red Hat builds of EC v0.6.
+rhtap-v0.6:
+  name: RHTAP
+  description: >-
+    Includes rules suitable for use with the attestations created by RHTAP.
+  environment: versioned
+  ecPoliciesRef: release-v0.6
+  include:
+    - '@rhtap-multi-ci'
+  exclude: []
+
+# Deprecated. RHTAP should now be using "rhtap-v0.6" or newer.
 rhtap-jenkins:
   name: RHTAP Jenkins
   description: >-
@@ -21,7 +32,9 @@ rhtap-jenkins:
   include:
     - '@rhtap-jenkins'
   exclude: []
+  deprecated: true
 
+# Deprecated. RHTAP should now be using "rhtap-v0.6" or newer.
 rhtap-gitlab:
   name: RHTAP GitLab
   description: >-
@@ -32,7 +45,9 @@ rhtap-gitlab:
   include:
     - '@rhtap-gitlab'
   exclude: []
+  deprecated: true
 
+# Deprecated. RHTAP should now be using "rhtap-v0.6" or newer.
 rhtap-github:
   name: RHTAP GitHub
   description: >-
@@ -43,6 +58,7 @@ rhtap-github:
   include:
     - '@rhtap-github'
   exclude: []
+  deprecated: true
 
 default-v0.1-alpha:
   name: Default (v0.1-alpha)


### PR DESCRIPTION
Also:

* Deprecate the older RHTAP multi-ci configs, (which removes them from the main readme but leaves the yaml in place)
* Include the version in the name so we can use the v0.6 "pinned" EC policies reference for better long-term stability.
    
Ref: https://issues.redhat.com/browse/EC-1135
