### PR TITLE
Deprecate old versioned default configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,22 +61,6 @@ suggested for use in [Red Hat Trusted Application Pipeline](https://developers.r
 
 The policy configuration files are:
 
-### Default (v0.1-alpha)
-
-Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.1-alpha.
-
-* URL for Enterprise Contract: `github.com/enterprise-contract/config//default-v0.1-alpha`
-* Source: [default-v0.1-alpha/policy.yaml](https://github.com/enterprise-contract/config/blob/main/default-v0.1-alpha/policy.yaml)
-* Collections: [@slsa3](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#slsa3)
-
-### Default (v0.2)
-
-Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.2.
-
-* URL for Enterprise Contract: `github.com/enterprise-contract/config//default-v0.2`
-* Source: [default-v0.2/policy.yaml](https://github.com/enterprise-contract/config/blob/main/default-v0.2/policy.yaml)
-* Collections: [@slsa3](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#slsa3)
-
 ### Default (v0.4)
 
 Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.4

--- a/default-v0.1-alpha/policy.yaml
+++ b/default-v0.1-alpha/policy.yaml
@@ -1,4 +1,6 @@
 #
+# ** DEPRECATED **
+#
 # To use this policy with the ec command line:
 #   ec validate image \
 #     --image $IMAGE \

--- a/default-v0.2/policy.yaml
+++ b/default-v0.2/policy.yaml
@@ -1,4 +1,6 @@
 #
+# ** DEPRECATED **
+#
 # To use this policy with the ec command line:
 #   ec validate image \
 #     --image $IMAGE \

--- a/src/data.yaml
+++ b/src/data.yaml
@@ -70,6 +70,7 @@ default-v0.1-alpha:
   include:
     - '@slsa3'
   exclude: []
+  deprecated: true
 
 default-v0.2:
   name: Default (v0.2)
@@ -81,6 +82,7 @@ default-v0.2:
   include:
     - '@slsa3'
   exclude: []
+  deprecated: true
 
 default-v0.4:
   name: Default (v0.4)


### PR DESCRIPTION
It's unlikely anyone needs or cares about these now, so let's deprecate them and declutter the main readme.