### PR TITLE
Add rpm trusted tasks data source

### DIFF
--- a/default/policy.yaml
+++ b/default/policy.yaml
@@ -32,8 +32,8 @@ sources:
       - github.com/enterprise-contract/ec-policies//policy/lib
       - github.com/enterprise-contract/ec-policies//policy/release
     data:
-      - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - github.com/release-engineering/rhtap-ec-policy//data
+      - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     config:
       include:
         - '@slsa3'

--- a/everything/policy.yaml
+++ b/everything/policy.yaml
@@ -34,8 +34,8 @@ sources:
       - github.com/enterprise-contract/ec-policies//policy/lib
       - github.com/enterprise-contract/ec-policies//policy/release
     data:
-      - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - github.com/release-engineering/rhtap-ec-policy//data
+      - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     config:
       include:
         - '*'

--- a/minimal/policy.yaml
+++ b/minimal/policy.yaml
@@ -34,8 +34,8 @@ sources:
       - github.com/enterprise-contract/ec-policies//policy/lib
       - github.com/enterprise-contract/ec-policies//policy/release
     data:
-      - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - github.com/release-engineering/rhtap-ec-policy//data
+      - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     config:
       include:
         - '@minimal'

--- a/redhat-no-hermetic/policy.yaml
+++ b/redhat-no-hermetic/policy.yaml
@@ -32,8 +32,8 @@ sources:
       - github.com/enterprise-contract/ec-policies//policy/lib
       - github.com/enterprise-contract/ec-policies//policy/release
     data:
-      - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - github.com/release-engineering/rhtap-ec-policy//data
+      - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     config:
       include:
         - '@redhat'

--- a/redhat-rpms/policy.yaml
+++ b/redhat-rpms/policy.yaml
@@ -34,6 +34,7 @@ sources:
     data:
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - github.com/release-engineering/rhtap-ec-policy//data
+      - oci::quay.io/enterprise-contract/rpmbuild-data-acceptable-bundles:latest
     config:
       include:
         - '@redhat_rpms'

--- a/redhat-rpms/policy.yaml
+++ b/redhat-rpms/policy.yaml
@@ -32,8 +32,8 @@ sources:
       - github.com/enterprise-contract/ec-policies//policy/lib
       - github.com/enterprise-contract/ec-policies//policy/release
     data:
-      - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - github.com/release-engineering/rhtap-ec-policy//data
+      - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - oci::quay.io/enterprise-contract/rpmbuild-data-acceptable-bundles:latest
     config:
       include:

--- a/redhat/policy.yaml
+++ b/redhat/policy.yaml
@@ -32,8 +32,8 @@ sources:
       - github.com/enterprise-contract/ec-policies//policy/lib
       - github.com/enterprise-contract/ec-policies//policy/release
     data:
-      - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - github.com/release-engineering/rhtap-ec-policy//data
+      - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     config:
       include:
         - '@redhat'

--- a/slsa3/policy.yaml
+++ b/slsa3/policy.yaml
@@ -32,8 +32,8 @@ sources:
       - github.com/enterprise-contract/ec-policies//policy/lib
       - github.com/enterprise-contract/ec-policies//policy/release
     data:
-      - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - github.com/release-engineering/rhtap-ec-policy//data
+      - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     config:
       include:
         - '@minimal'

--- a/src/data.yaml
+++ b/src/data.yaml
@@ -152,6 +152,8 @@ redhat-rpms:
   include:
     - '@redhat_rpms'
   exclude: []
+  extra-data:
+    - oci::quay.io/enterprise-contract/rpmbuild-data-acceptable-bundles:latest
 
 slsa3:
   name: SLSA3

--- a/src/policy-konflux.yaml.tmpl
+++ b/src/policy-konflux.yaml.tmpl
@@ -39,6 +39,9 @@ sources:
     data:
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - github.com/release-engineering/rhtap-ec-policy//data
+      {{- range index . "extra-data" }}
+      - {{ . }}
+      {{- end }}
     config:
       include:
         {{ .include | toYAML | strings.Indent 8 | strings.TrimSpace }}

--- a/src/policy-konflux.yaml.tmpl
+++ b/src/policy-konflux.yaml.tmpl
@@ -37,8 +37,8 @@ sources:
       - github.com/enterprise-contract/ec-policies//policy/lib
       - github.com/enterprise-contract/ec-policies//policy/release
     data:
-      - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - github.com/release-engineering/rhtap-ec-policy//data
+      - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       {{- range index . "extra-data" }}
       - {{ . }}
       {{- end }}


### PR DESCRIPTION
Make use of the new bundle created in https://issues.redhat.com/browse/EC-1203 so we can see the list of trusted rpm-specific task definitions defined in the internal gitlab.