### PR TITLE
chore: update references to policy repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Includes rules for levels 1, 2 & 3 of SLSA v0.1. This is the default config used
 
 * URL for Enterprise Contract: `github.com/enterprise-contract/config//default`
 * Source: [default/policy.yaml](https://github.com/enterprise-contract/config/blob/main/default/policy.yaml)
-* Collections: [@slsa3](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#slsa3)
+* Collections: [@slsa3](https://enterprisecontract.dev/docs/policy/release_policy.html#slsa3)
 
 ### Red Hat
 
@@ -27,7 +27,7 @@ Includes the full set of rules and policies required internally by Red Hat when 
 
 * URL for Enterprise Contract: `github.com/enterprise-contract/config//redhat`
 * Source: [redhat/policy.yaml](https://github.com/enterprise-contract/config/blob/main/redhat/policy.yaml)
-* Collections: [@redhat](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#redhat)
+* Collections: [@redhat](https://enterprisecontract.dev/docs/policy/release_policy.html#redhat)
 
 ### Red Hat (non hermetic)
 
@@ -35,7 +35,7 @@ Includes most of the rules and policies required internally by Red Hat when buil
 
 * URL for Enterprise Contract: `github.com/enterprise-contract/config//redhat-no-hermetic`
 * Source: [redhat-no-hermetic/policy.yaml](https://github.com/enterprise-contract/config/blob/main/redhat-no-hermetic/policy.yaml)
-* Collections: [@redhat](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#redhat)
+* Collections: [@redhat](https://enterprisecontract.dev/docs/policy/release_policy.html#redhat)
 
 ### Red Hat RPMs
 
@@ -43,7 +43,7 @@ For Red Hat RPM builds in Red Hat Konflux.
 
 * URL for Enterprise Contract: `github.com/enterprise-contract/config//redhat-rpms`
 * Source: [redhat-rpms/policy.yaml](https://github.com/enterprise-contract/config/blob/main/redhat-rpms/policy.yaml)
-* Collections: [@redhat_rpms](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#redhat_rpms)
+* Collections: [@redhat_rpms](https://enterprisecontract.dev/docs/policy/release_policy.html#redhat_rpms)
 
 ### SLSA3
 
@@ -51,12 +51,12 @@ Rules specifically related to levels 1, 2 & 3 of SLSA v0.1, plus a set of basic 
 
 * URL for Enterprise Contract: `github.com/enterprise-contract/config//slsa3`
 * Source: [slsa3/policy.yaml](https://github.com/enterprise-contract/config/blob/main/slsa3/policy.yaml)
-* Collections: [@minimal](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#minimal), [@slsa3](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#slsa3)
+* Collections: [@minimal](https://enterprisecontract.dev/docs/policy/release_policy.html#minimal), [@slsa3](https://enterprisecontract.dev/docs/policy/release_policy.html#slsa3)
 
 
 ## Stable (versioned policies)
 
-The main branch of the [enterprise-contract/ec-policies](https://github.com/enterprise-contract/ec-policies)
+The main branch of the [conforma/policy](https://github.com/conforma/policy)
 is always tested with the [latest build of ec-cli](https://github.com/enterprise-contract/ec-cli/releases). If
 your environment uses a specific version of ec-cli, such as
 [the official Red Hat build](https://catalog.redhat.com/software/containers/rhtas/ec-rhel9/65f1f9dcfc649a18c6075de5),
@@ -75,7 +75,7 @@ Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.4
 
 * URL for Enterprise Contract: `github.com/enterprise-contract/config//default-v0.4`
 * Source: [default-v0.4/policy.yaml](https://github.com/enterprise-contract/config/blob/main/default-v0.4/policy.yaml)
-* Collections: [@slsa3](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#slsa3)
+* Collections: [@slsa3](https://enterprisecontract.dev/docs/policy/release_policy.html#slsa3)
 
 ### RHTAP
 
@@ -83,7 +83,7 @@ Includes rules suitable for use with the attestations created by RHTAP.
 
 * URL for Enterprise Contract: `github.com/enterprise-contract/config//rhtap-v0.6`
 * Source: [rhtap-v0.6/policy.yaml](https://github.com/enterprise-contract/config/blob/main/rhtap-v0.6/policy.yaml)
-* Collections: [@rhtap-multi-ci](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#rhtap-multi-ci)
+* Collections: [@rhtap-multi-ci](https://enterprisecontract.dev/docs/policy/release_policy.html#rhtap-multi-ci)
 
 ### Tekton SLSA3 (v0.6)
 
@@ -91,7 +91,7 @@ Includes rules for levels 1, 2 & 3 of SLSA v0.1. For use with ec version v0.6
 
 * URL for Enterprise Contract: `github.com/enterprise-contract/config//tekton-slsa3-v0.6`
 * Source: [tekton-slsa3-v0.6/policy.yaml](https://github.com/enterprise-contract/config/blob/main/tekton-slsa3-v0.6/policy.yaml)
-* Collections: [@slsa3](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#slsa3)
+* Collections: [@slsa3](https://enterprisecontract.dev/docs/policy/release_policy.html#slsa3)
 
 
 ## Konflux CI & Red Hat Trusted Application Pipeline (RHTAP) - Tasks
@@ -120,9 +120,9 @@ Rules for container images built via GitHub Workflows.
 
 * URL for Enterprise Contract: `github.com/enterprise-contract/config//github-default`
 * Source: [github-default/policy.yaml](https://github.com/enterprise-contract/config/blob/main/github-default/policy.yaml)
-* Collections: [@github](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#github)
+* Collections: [@github](https://enterprisecontract.dev/docs/policy/release_policy.html#github)
 
 ## See also
 
-* [Policy Rule Documentation](https://enterprisecontract.dev/docs/ec-policies/release_policy.html)
+* [Policy Rule Documentation](https://enterprisecontract.dev/docs/policy/release_policy.html)
 * [Getting Started with Enterprise Contract &amp; Konflux CI](https://enterprisecontract.dev/docs/user-guide/getting-started.html)

--- a/default-v0.1-alpha/policy.yaml
+++ b/default-v0.1-alpha/policy.yaml
@@ -14,8 +14,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib?ref=release-v0.1-alpha
-      - github.com/enterprise-contract/ec-policies//policy/release?ref=release-v0.1-alpha
+      - github.com/conforma/policy//policy/lib?ref=release-v0.1-alpha
+      - github.com/conforma/policy//policy/release?ref=release-v0.1-alpha
     data: []
     config:
       include:

--- a/default-v0.2/policy.yaml
+++ b/default-v0.2/policy.yaml
@@ -14,8 +14,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib?ref=release-v0.2
-      - github.com/enterprise-contract/ec-policies//policy/release?ref=release-v0.2
+      - github.com/conforma/policy//policy/lib?ref=release-v0.2
+      - github.com/conforma/policy//policy/release?ref=release-v0.2
     data: []
     config:
       include:

--- a/default-v0.4/policy.yaml
+++ b/default-v0.4/policy.yaml
@@ -12,8 +12,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib?ref=release-v0.4
-      - github.com/enterprise-contract/ec-policies//policy/release?ref=release-v0.4
+      - github.com/conforma/policy//policy/lib?ref=release-v0.4
+      - github.com/conforma/policy//policy/release?ref=release-v0.4
     data: []
     config:
       include:

--- a/default/policy.yaml
+++ b/default/policy.yaml
@@ -18,7 +18,7 @@
 # the param value instead of the GitHub URL.
 #
 # See also:
-# - https://enterprisecontract.dev/docs/ec-policies/release_policy.html#_available_rule_collections
+# - https://enterprisecontract.dev/docs/policy/release_policy.html#_available_rule_collections
 # - https://enterprisecontract.dev/docs/ec-cli/main/configuration.html
 #
 name: Default
@@ -29,8 +29,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib
-      - github.com/enterprise-contract/ec-policies//policy/release
+      - github.com/conforma/policy//policy/lib
+      - github.com/conforma/policy//policy/release
     data:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest

--- a/everything/policy.yaml
+++ b/everything/policy.yaml
@@ -20,7 +20,7 @@
 # the param value instead of the GitHub URL.
 #
 # See also:
-# - https://enterprisecontract.dev/docs/ec-policies/release_policy.html#_available_rule_collections
+# - https://enterprisecontract.dev/docs/policy/release_policy.html#_available_rule_collections
 # - https://enterprisecontract.dev/docs/ec-cli/main/configuration.html
 #
 name: Everything (experimental)
@@ -31,8 +31,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib
-      - github.com/enterprise-contract/ec-policies//policy/release
+      - github.com/conforma/policy//policy/lib
+      - github.com/conforma/policy//policy/release
     data:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest

--- a/github-default/policy.yaml
+++ b/github-default/policy.yaml
@@ -12,8 +12,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib
-      - github.com/enterprise-contract/ec-policies//policy/release
+      - github.com/conforma/policy//policy/lib
+      - github.com/conforma/policy//policy/release
     data: []
     config:
       include:

--- a/minimal/policy.yaml
+++ b/minimal/policy.yaml
@@ -20,7 +20,7 @@
 # the param value instead of the GitHub URL.
 #
 # See also:
-# - https://enterprisecontract.dev/docs/ec-policies/release_policy.html#_available_rule_collections
+# - https://enterprisecontract.dev/docs/policy/release_policy.html#_available_rule_collections
 # - https://enterprisecontract.dev/docs/ec-cli/main/configuration.html
 #
 name: Minimal (deprecated)
@@ -31,8 +31,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib
-      - github.com/enterprise-contract/ec-policies//policy/release
+      - github.com/conforma/policy//policy/lib
+      - github.com/conforma/policy//policy/release
     data:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest

--- a/redhat-no-hermetic/policy.yaml
+++ b/redhat-no-hermetic/policy.yaml
@@ -18,7 +18,7 @@
 # the param value instead of the GitHub URL.
 #
 # See also:
-# - https://enterprisecontract.dev/docs/ec-policies/release_policy.html#_available_rule_collections
+# - https://enterprisecontract.dev/docs/policy/release_policy.html#_available_rule_collections
 # - https://enterprisecontract.dev/docs/ec-cli/main/configuration.html
 #
 name: Red Hat (non hermetic)
@@ -29,8 +29,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib
-      - github.com/enterprise-contract/ec-policies//policy/release
+      - github.com/conforma/policy//policy/lib
+      - github.com/conforma/policy//policy/release
     data:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest

--- a/redhat-rpms/policy.yaml
+++ b/redhat-rpms/policy.yaml
@@ -18,7 +18,7 @@
 # the param value instead of the GitHub URL.
 #
 # See also:
-# - https://enterprisecontract.dev/docs/ec-policies/release_policy.html#_available_rule_collections
+# - https://enterprisecontract.dev/docs/policy/release_policy.html#_available_rule_collections
 # - https://enterprisecontract.dev/docs/ec-cli/main/configuration.html
 #
 name: Red Hat RPMs
@@ -29,8 +29,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib
-      - github.com/enterprise-contract/ec-policies//policy/release
+      - github.com/conforma/policy//policy/lib
+      - github.com/conforma/policy//policy/release
     data:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest

--- a/redhat-trusted-tasks/policy.yaml
+++ b/redhat-trusted-tasks/policy.yaml
@@ -9,8 +9,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib
-      - github.com/enterprise-contract/ec-policies//policy/task
+      - github.com/conforma/policy//policy/lib
+      - github.com/conforma/policy//policy/task
     data:
       - github.com/release-engineering/rhtap-ec-policy//data
     config:

--- a/redhat/policy.yaml
+++ b/redhat/policy.yaml
@@ -18,7 +18,7 @@
 # the param value instead of the GitHub URL.
 #
 # See also:
-# - https://enterprisecontract.dev/docs/ec-policies/release_policy.html#_available_rule_collections
+# - https://enterprisecontract.dev/docs/policy/release_policy.html#_available_rule_collections
 # - https://enterprisecontract.dev/docs/ec-cli/main/configuration.html
 #
 name: Red Hat
@@ -29,8 +29,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib
-      - github.com/enterprise-contract/ec-policies//policy/release
+      - github.com/conforma/policy//policy/lib
+      - github.com/conforma/policy//policy/release
     data:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest

--- a/rhtap-github/policy.yaml
+++ b/rhtap-github/policy.yaml
@@ -14,8 +14,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib?ref=release-v0.5-rhtap
-      - github.com/enterprise-contract/ec-policies//policy/release?ref=release-v0.5-rhtap
+      - github.com/conforma/policy//policy/lib?ref=release-v0.5-rhtap
+      - github.com/conforma/policy//policy/release?ref=release-v0.5-rhtap
     data: []
     config:
       include:

--- a/rhtap-gitlab/policy.yaml
+++ b/rhtap-gitlab/policy.yaml
@@ -14,8 +14,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib?ref=release-v0.5-rhtap
-      - github.com/enterprise-contract/ec-policies//policy/release?ref=release-v0.5-rhtap
+      - github.com/conforma/policy//policy/lib?ref=release-v0.5-rhtap
+      - github.com/conforma/policy//policy/release?ref=release-v0.5-rhtap
     data: []
     config:
       include:

--- a/rhtap-jenkins/policy.yaml
+++ b/rhtap-jenkins/policy.yaml
@@ -14,8 +14,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib?ref=release-v0.5
-      - github.com/enterprise-contract/ec-policies//policy/release?ref=release-v0.5
+      - github.com/conforma/policy//policy/lib?ref=release-v0.5
+      - github.com/conforma/policy//policy/release?ref=release-v0.5
     data: []
     config:
       include:

--- a/rhtap-v0.6/policy.yaml
+++ b/rhtap-v0.6/policy.yaml
@@ -12,8 +12,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib?ref=release-v0.6
-      - github.com/enterprise-contract/ec-policies//policy/release?ref=release-v0.6
+      - github.com/conforma/policy//policy/lib?ref=release-v0.6
+      - github.com/conforma/policy//policy/release?ref=release-v0.6
     data: []
     config:
       include:

--- a/slsa3/policy.yaml
+++ b/slsa3/policy.yaml
@@ -18,7 +18,7 @@
 # the param value instead of the GitHub URL.
 #
 # See also:
-# - https://enterprisecontract.dev/docs/ec-policies/release_policy.html#_available_rule_collections
+# - https://enterprisecontract.dev/docs/policy/release_policy.html#_available_rule_collections
 # - https://enterprisecontract.dev/docs/ec-cli/main/configuration.html
 #
 name: SLSA3
@@ -29,8 +29,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib
-      - github.com/enterprise-contract/ec-policies//policy/release
+      - github.com/conforma/policy//policy/lib
+      - github.com/conforma/policy//policy/release
     data:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest

--- a/src/README-github.md.tmpl
+++ b/src/README-github.md.tmpl
@@ -8,7 +8,7 @@
 * Collections:{{ $comma := false }}{{ range .include -}}
   {{- if strings.HasPrefix "@" . -}}
     {{- if not $comma }}{{ $comma = true }} {{ else }}, {{ end -}}
-    [{{ . }}](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#{{ strings.TrimPrefix "@" . }})
+    [{{ . }}](https://enterprisecontract.dev/docs/policy/release_policy.html#{{ strings.TrimPrefix "@" . }})
   {{- end -}}
 {{- end }}
 {{- end }}

--- a/src/README-konflux.md.tmpl
+++ b/src/README-konflux.md.tmpl
@@ -8,7 +8,7 @@
 * Collections:{{ $comma := false }}{{ range .include -}}
   {{- if strings.HasPrefix "@" . -}}
     {{- if not $comma }}{{ $comma = true }} {{ else }}, {{ end -}}
-    [{{ . }}](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#{{ strings.TrimPrefix "@" . }})
+    [{{ . }}](https://enterprisecontract.dev/docs/policy/release_policy.html#{{ strings.TrimPrefix "@" . }})
   {{- end -}}
 {{- end }}
 {{- end }}

--- a/src/README-versioned.md.tmpl
+++ b/src/README-versioned.md.tmpl
@@ -8,7 +8,7 @@
 * Collections:{{ $comma := false }}{{ range .include -}}
   {{- if strings.HasPrefix "@" . -}}
     {{- if not $comma }}{{ $comma = true }} {{ else }}, {{ end -}}
-    [{{ . }}](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#{{ strings.TrimPrefix "@" . }})
+    [{{ . }}](https://enterprisecontract.dev/docs/policy/release_policy.html#{{ strings.TrimPrefix "@" . }})
   {{- end -}}
 {{- end }}
 {{- end }}

--- a/src/README.md.tmpl
+++ b/src/README.md.tmpl
@@ -24,7 +24,7 @@ The policy configuration files are:
 
 ## Stable (versioned policies)
 
-The main branch of the [enterprise-contract/ec-policies](https://github.com/enterprise-contract/ec-policies)
+The main branch of the [conforma/policy](https://github.com/conforma/policy)
 is always tested with the [latest build of ec-cli](https://github.com/enterprise-contract/ec-cli/releases). If
 your environment uses a specific version of ec-cli, such as
 [the official Red Hat build](https://catalog.redhat.com/software/containers/rhtas/ec-rhel9/65f1f9dcfc649a18c6075de5),
@@ -77,5 +77,5 @@ the following policy configurations.
 {{- end }}
 ## See also
 
-* [Policy Rule Documentation](https://enterprisecontract.dev/docs/ec-policies/release_policy.html)
+* [Policy Rule Documentation](https://enterprisecontract.dev/docs/policy/release_policy.html)
 * [Getting Started with Enterprise Contract &amp; Konflux CI](https://enterprisecontract.dev/docs/user-guide/getting-started.html)

--- a/src/policy-github.yaml.tmpl
+++ b/src/policy-github.yaml.tmpl
@@ -17,8 +17,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib
-      - github.com/enterprise-contract/ec-policies//policy/release
+      - github.com/conforma/policy//policy/lib
+      - github.com/conforma/policy//policy/release
     data: []
     config:
       include:

--- a/src/policy-konflux-tasks.yaml.tmpl
+++ b/src/policy-konflux-tasks.yaml.tmpl
@@ -10,8 +10,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib
-      - github.com/enterprise-contract/ec-policies//policy/task
+      - github.com/conforma/policy//policy/lib
+      - github.com/conforma/policy//policy/task
     data:
       - github.com/release-engineering/rhtap-ec-policy//data
     config:

--- a/src/policy-konflux.yaml.tmpl
+++ b/src/policy-konflux.yaml.tmpl
@@ -23,7 +23,7 @@
 # the param value instead of the GitHub URL.
 #
 # See also:
-# - https://enterprisecontract.dev/docs/ec-policies/release_policy.html#_available_rule_collections
+# - https://enterprisecontract.dev/docs/policy/release_policy.html#_available_rule_collections
 # - https://enterprisecontract.dev/docs/ec-cli/main/configuration.html
 #
 name: {{.name}}
@@ -34,8 +34,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib
-      - github.com/enterprise-contract/ec-policies//policy/release
+      - github.com/conforma/policy//policy/lib
+      - github.com/conforma/policy//policy/release
     data:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest

--- a/src/policy-versioned.yaml.tmpl
+++ b/src/policy-versioned.yaml.tmpl
@@ -17,8 +17,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib{{ with .ecPoliciesRef }}?ref={{ . }}{{ end }}
-      - github.com/enterprise-contract/ec-policies//policy/release{{ with .ecPoliciesRef }}?ref={{ . }}{{ end }}
+      - github.com/conforma/policy//policy/lib{{ with .ecPoliciesRef }}?ref={{ . }}{{ end }}
+      - github.com/conforma/policy//policy/release{{ with .ecPoliciesRef }}?ref={{ . }}{{ end }}
     data: []
     config:
       include:

--- a/tekton-slsa3-v0.6/policy.yaml
+++ b/tekton-slsa3-v0.6/policy.yaml
@@ -12,8 +12,8 @@ description: >-
 sources:
   - name: Default
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib?ref=release-v0.6
-      - github.com/enterprise-contract/ec-policies//policy/release?ref=release-v0.6
+      - github.com/conforma/policy//policy/lib?ref=release-v0.6
+      - github.com/conforma/policy//policy/release?ref=release-v0.6
     data: []
     config:
       include:


### PR DESCRIPTION
This commit updates references to the ec-policies repo from `enterprise-contract/ec-policies` to `conforma/policy`.

Ref: EC-1113