### PR TITLE
chore(KFLUXVNGD-298): add konflux-vanguard to trusted-tasks

### DIFF
--- a/default/policy.yaml
+++ b/default/policy.yaml
@@ -34,6 +34,7 @@ sources:
     data:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+      - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
     config:
       include:
         - '@slsa3'

--- a/everything/policy.yaml
+++ b/everything/policy.yaml
@@ -36,6 +36,7 @@ sources:
     data:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+      - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
     config:
       include:
         - '*'

--- a/minimal/policy.yaml
+++ b/minimal/policy.yaml
@@ -36,6 +36,7 @@ sources:
     data:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+      - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
     config:
       include:
         - '@minimal'

--- a/redhat-no-hermetic/policy.yaml
+++ b/redhat-no-hermetic/policy.yaml
@@ -34,6 +34,7 @@ sources:
     data:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+      - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
     config:
       include:
         - '@redhat'

--- a/redhat-rpms/policy.yaml
+++ b/redhat-rpms/policy.yaml
@@ -34,6 +34,7 @@ sources:
     data:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+      - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
       - oci::quay.io/enterprise-contract/rpmbuild-data-acceptable-bundles:latest
     config:
       include:

--- a/redhat/policy.yaml
+++ b/redhat/policy.yaml
@@ -34,6 +34,7 @@ sources:
     data:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+      - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
     config:
       include:
         - '@redhat'

--- a/slsa3/policy.yaml
+++ b/slsa3/policy.yaml
@@ -34,6 +34,7 @@ sources:
     data:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+      - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
     config:
       include:
         - '@minimal'

--- a/src/policy-konflux.yaml.tmpl
+++ b/src/policy-konflux.yaml.tmpl
@@ -39,6 +39,7 @@ sources:
     data:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+      - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
       {{- range index . "extra-data" }}
       - {{ . }}
       {{- end }}


### PR DESCRIPTION
Add konflux-vanguard acceptable-bundles to the policies

As part of decentralizing build-definitions, teams will build and release their own tasks using Konflux
instead of building them in build-definitions.
Each team will have its own data-acceptable-bundles OCI artifact with their trusted tasks.
In order for the policies to recognize the tasks as trusted tasks we need to add this list of trusted tasks
(data-acceptable-bundles OCI) to the policies.
This MR is for adding Konlux-vangurad list of trusted tasks (for example rpms-signature-scan task)